### PR TITLE
Use fixed GRIDSS container for VIRUSBreakend

### DIFF
--- a/modules/local/virusbreakend/Dockerfile
+++ b/modules/local/virusbreakend/Dockerfile
@@ -1,31 +1,31 @@
 FROM continuumio/miniconda3:23.5.2-0-alpine as build
 
 RUN \
-  conda install conda-libmamba-solver
+    conda install conda-libmamba-solver
 
 RUN \
-  echo -e > ~/.condarc '\
+    echo -e > ~/.condarc '\
 solver: libmamba\n\
 channels:\n\
-  - conda-forge\n\
-  - bioconda\n\
-  - defaults'
+    - conda-forge\n\
+    - bioconda\n\
+    - defaults'
 
 RUN \
-  conda create -y -p /env/ \
-    'gridss=2.13.2=h50ea8bc_3' \
-    'bash' \
-    'coreutils' \
-    'findutils' \
-    'gawk' \
-    'grep' \
-    'procps-ng' \
-    'time' \
-    'util-linux' \
-    'which'
+    conda create -y -p /env/ \
+        'gridss=2.13.2=h50ea8bc_3' \
+        'bash' \
+        'coreutils' \
+        'findutils' \
+        'gawk' \
+        'grep' \
+        'procps-ng' \
+        'time' \
+        'util-linux' \
+        'which'
 
 RUN \
-  conda clean -yaf
+    conda clean -yaf
 
 # Move Conda environment into distroless image
 FROM gcr.io/distroless/base-debian11:latest
@@ -38,6 +38,6 @@ ENV LD_LIBRARY_PATH="/env/lib/:${LD_LIBRARY_PATH}"
 # Symlink system executables as required by VIRUSBreaked
 SHELL ["/env/bin/bash", "-c"]
 RUN \
-  ln -s /env/bin/bash /bin/bash && \
-  ln -s /env/bin/env /usr/bin/env && \
-  ln -s /env/bin/time /usr/bin/time
+    ln -s /env/bin/bash /bin/bash && \
+    ln -s /env/bin/env /usr/bin/env && \
+    ln -s /env/bin/time /usr/bin/time

--- a/modules/local/virusbreakend/Dockerfile
+++ b/modules/local/virusbreakend/Dockerfile
@@ -1,0 +1,43 @@
+FROM continuumio/miniconda3:23.5.2-0-alpine as build
+
+RUN \
+  conda install conda-libmamba-solver
+
+RUN \
+  echo -e > ~/.condarc '\
+solver: libmamba\n\
+channels:\n\
+  - conda-forge\n\
+  - bioconda\n\
+  - defaults'
+
+RUN \
+  conda create -y -p /env/ \
+    'gridss=2.13.2=h50ea8bc_3' \
+    'bash' \
+    'coreutils' \
+    'findutils' \
+    'gawk' \
+    'grep' \
+    'procps-ng' \
+    'time' \
+    'util-linux' \
+    'which'
+
+RUN \
+  conda clean -yaf
+
+# Move Conda environment into distroless image
+FROM gcr.io/distroless/base-debian11:latest
+
+COPY --from=build /env/ /env/
+
+ENV PATH="/env/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/env/lib/:${LD_LIBRARY_PATH}"
+
+# Symlink system executables as required by VIRUSBreaked
+SHELL ["/env/bin/bash", "-c"]
+RUN \
+  ln -s /env/bin/bash /bin/bash && \
+  ln -s /env/bin/env /usr/bin/env && \
+  ln -s /env/bin/time /usr/bin/time

--- a/modules/local/virusbreakend/main.nf
+++ b/modules/local/virusbreakend/main.nf
@@ -6,8 +6,8 @@ process VIRUSBREAKEND {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gridss:2.13.2--h50ea8bc_3':
-        'quay.io/biocontainers/gridss:2.13.2--h50ea8bc_3' }"
+        'https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/singularity/gridss:2.13.2--0' :
+        'quay.io/nf-core/gridss:2.13.2--0' }"
 
     input:
     tuple val(meta), path(bam)


### PR DESCRIPTION
### Background

- VIRUSBreakend is a tool that exists alongside GRIDSS and is available through **[PapenfussLab/gridss](https://github.com/PapenfussLab/gridss)**
- The VIRUSBreakend but not GRIDSS execution script makes heavy use of grep, however the corresponding BioContainers Docker image currently used in oncoanalyser only provides BusyBox grep
- BusyBox grep has very poor performance compared to GNU grep and increases VIRUSBreakend runtime by ~1 hour
- I've attempted to replace BusyBox grep with GNU grep in the Bioconda recipe but their CI infrastructure doesn't have sufficient disk space to build + test the relevant artifacts
  - I've previously had good builds on Bioconda but they now consistently fail because of insufficient disk space
  - See: https://github.com/bioconda/bioconda-recipes/pull/46160
  - The main cause is the RepeatMasker database size, which the Bioconda community is actively trying to resolve
- Fixing this problem through Bioconda is not currently possible as far as I can tell

### Changes

For a temporary fix, I have done the following:

- Created a Dockerfile specifically to restore VIRUSBreakend performance by using GNU grep
- Uploaded the containers:
  - Docker image: `docker.io/scwatts/gridss:2.13.2--0`
  - Singularity image: `https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/singularity/gridss:2.13.2--0`
- Adjusted VIRUSBreakend NF process container directive accordingly

The new VIRUSBreakend Docker image and Singularity have been successfully tested using the COLO829 mini dataset.

### Additional requirements

The Docker image would need to be pushed to the nf-core Quay account:

```bash
docker pull docker.io/scwatts/gridss:2.13.2--0
docker tag docker.io/scwatts/gridss:2.13.2--0 quay.io/nf-core/gridss:2.13.2--0
docker push quay.io/nf-core/gridss:2.13.2--0
```

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/oncoanalyser/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/oncoanalyser _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).