### PR TITLE
Update reference data URLs

### DIFF
--- a/conf/hmf_genomes.config
+++ b/conf/hmf_genomes.config
@@ -10,26 +10,26 @@
 params {
     genomes {
         'GRCh37_hmf' {
-            fasta           = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh37_hmf/Homo_sapiens.GRCh37.GATK.illumina.fasta"
-            fai             = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh37_hmf/samtools_index/1.16/Homo_sapiens.GRCh37.GATK.illumina.fasta.fai"
-            dict            = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh37_hmf/samtools_index/1.16/Homo_sapiens.GRCh37.GATK.illumina.fasta.dict"
-            bwa_index       = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh37_hmf/bwa_index/0.7.17-r1188.tar.gz"
-            bwa_index_bseq  = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh37_hmf/bwa_index/2.2.1/Homo_sapiens.GRCh37.GATK.illumina.fasta.0123"
-            bwa_index_biidx = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh37_hmf/bwa_index/2.2.1/Homo_sapiens.GRCh37.GATK.illumina.fasta.bwt.2bit.64"
-            bwa_index_image = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh37_hmf/bwa_index_image/0.7.17-r1188/Homo_sapiens.GRCh37.GATK.illumina.fasta.img"
-            gridss_index    = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh37_hmf/gridss_index/2.13.2/Homo_sapiens.GRCh37.GATK.illumina.fasta.gridsscache"
-            star_index      = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh37_hmf/star_index/gencode_19/2.7.3a.tar.gz"
+            fasta           = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/Homo_sapiens.GRCh37.GATK.illumina.fasta"
+            fai             = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/samtools_index/1.16/Homo_sapiens.GRCh37.GATK.illumina.fasta.fai"
+            dict            = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/samtools_index/1.16/Homo_sapiens.GRCh37.GATK.illumina.fasta.dict"
+            bwa_index       = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/bwa_index/0.7.17-r1188.tar.gz"
+            bwa_index_bseq  = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/bwa_index/2.2.1/Homo_sapiens.GRCh37.GATK.illumina.fasta.0123"
+            bwa_index_biidx = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/bwa_index/2.2.1/Homo_sapiens.GRCh37.GATK.illumina.fasta.bwt.2bit.64"
+            bwa_index_image = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/bwa_index_image/0.7.17-r1188/Homo_sapiens.GRCh37.GATK.illumina.fasta.img"
+            gridss_index    = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/gridss_index/2.13.2/Homo_sapiens.GRCh37.GATK.illumina.fasta.gridsscache"
+            star_index      = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/star_index/gencode_19/2.7.3a.tar.gz"
         }
         'GRCh38_hmf' {
-            fasta           = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh38_hmf/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna"
-            fai             = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh38_hmf/samtools_index/1.16/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.fai"
-            dict            = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh38_hmf/samtools_index/1.16/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.dict"
-            bwa_index       = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh38_hmf/bwa_index/0.7.17-r1188.tar.gz"
-            bwa_index_bseq  = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh38_hmf/bwa_index/2.2.1/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.0123"
-            bwa_index_biidx = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh38_hmf/bwa_index/2.2.1/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.bwt.2bit.64"
-            bwa_index_image = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh38_hmf/bwa_index_image/0.7.17-r1188/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.img"
-            gridss_index    = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh38_hmf/gridss_index/2.13.2/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gridsscache"
-            star_index      = "https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/genomes/GRCh38_hmf/star_index/gencode_38/2.7.3a.tar.gz"
+            fasta           = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna"
+            fai             = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/samtools_index/1.16/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.fai"
+            dict            = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/samtools_index/1.16/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.dict"
+            bwa_index       = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/bwa_index/0.7.17-r1188.tar.gz"
+            bwa_index_bseq  = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/bwa_index/2.2.1/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.0123"
+            bwa_index_biidx = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/bwa_index/2.2.1/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.bwt.2bit.64"
+            bwa_index_image = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/bwa_index_image/0.7.17-r1188/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.img"
+            gridss_index    = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/gridss_index/2.13.2/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gridsscache"
+            star_index      = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/star_index/gencode_38/2.7.3a.tar.gz"
         }
     }
 }

--- a/lib/Constants.groovy
+++ b/lib/Constants.groovy
@@ -11,17 +11,17 @@ class Constants {
     static List PANELS_DEFINED     = ['tso500']
 
 
-    static String HMF_DATA_37_PATH = 'https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/hmf_reference_data/hmftools/5.34_37--2.tar.gz'
-    static String HMF_DATA_38_PATH = 'https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/hmf_reference_data/hmftools/5.34_38--2.tar.gz'
+    static String HMF_DATA_37_PATH = 'https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/hmf_reference_data/hmftools/5.34_37--2.tar.gz'
+    static String HMF_DATA_38_PATH = 'https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/hmf_reference_data/hmftools/5.34_38--2.tar.gz'
 
 
-    static String TSO500_PANEL_37_PATH = 'https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/hmf_reference_data/panels/tso500_5.34_37--1.tar.gz'
-    static String TSO500_PANEL_38_PATH = 'https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/hmf_reference_data/panels/tso500_5.34_38--1.tar.gz'
+    static String TSO500_PANEL_37_PATH = 'https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/hmf_reference_data/panels/tso500_5.34_37--1.tar.gz'
+    static String TSO500_PANEL_38_PATH = 'https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/hmf_reference_data/panels/tso500_5.34_38--1.tar.gz'
 
 
-    static String VIRUSBREAKENDDB_PATH = 'https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/virusbreakend/virusbreakenddb_20210401.tar.gz'
+    static String VIRUSBREAKENDDB_PATH = 'https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/virusbreakend/virusbreakenddb_20210401.tar.gz'
 
-    static String HLA_SLICE_BED_GRCH38_ALT_PATH = 'https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/umccr_reference_data/other/hla_slice/grch38_alt.plus_homologous.bed'
+    static String HLA_SLICE_BED_GRCH38_ALT_PATH = 'https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/other/hla_slice/grch38_alt.plus_homologous.bed'
 
 
     static Integer DEFAULT_ISOFOX_READ_LENGTH_WTS = 151


### PR DESCRIPTION
- copy reference data to a dedicated oncoanalyser bucket on Cloudflare R2
- version genomes to anticipate upcoming Ensembl updates and potential index reorganisation
- retain existing reference data to maintain backwards compatibility with aim to delete following 1.0.0 release