### PR TITLE
Improve GHA CI workflow step name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test:
-    name: Run pipeline with test data
+    name: Run pipeline stubs
     # Only run on push if this is the nf-core dev branch (merged PRs)
     if: "${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/oncoanalyser') }}"
     runs-on: ubuntu-latest


### PR DESCRIPTION
- the GHA CI job runs only stubs rather than with actual test data due to disk limitations of GHA runner instances
- job step name: `Run pipeline with test data` → `Run pipeline stubs`