### PR TITLE
Set bwa-mem2 batch size for reproducibility

### DIFF
--- a/modules/local/bwa-mem2/mem/main.nf
+++ b/modules/local/bwa-mem2/mem/main.nf
@@ -28,6 +28,7 @@ process BWAMEM2_ALIGN {
 
     bwa-mem2 mem \\
         -Y \\
+        -K 100000000 \\
         -R '${read_group_tag}' \\
         -t ${task.cpus} \\
         ${genome_fasta} \\


### PR DESCRIPTION
- improve reproducibility for bwa-mem2 alignments by setting `-K`
- this ensures that the number of input bases in each batch is consistent
- the parameter value was selected to match configuration used in Sarek