### PR TITLE
Use simulated data for pipeline tests

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -10,6 +10,12 @@
 ----------------------------------------------------------------------------------------
 */
 
+process {
+    withName: 'PURPLE' {
+        ext.args = '-min_purity 1 -max_purity 1 -min_ploidy 2 -max_ploidy 2'
+    }
+}
+
 params {
     config_profile_name        = 'Test profile'
     config_profile_description = 'Minimal test dataset to check pipeline function'
@@ -18,16 +24,17 @@ params {
     // execution.
     validationSchemaIgnoreParams = 'genomes,hmf_data_paths,panel_data_paths'
 
+    // NOTE(SW): incompatible with GHA given size of reference data
     // Limit resources so that this can run on GitHub Actions
     max_cpus   = 1
     max_memory = '8.GB'
     max_time   = '6.h'
 
     // Input data
-    input = 'https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/oncoanalyser/test_data/other/samplesheet.colo829_mini.dna_rna.grch38_hmf.csv'
+    input = 'https://pub-349bcb8decb44bf7acbddf90b270a061.r2.dev/simulated_reads/24.0/samplesheets/fastq_eval.subject_a-subject_b.wgts.tndna_trna.1.csv'
 
     mode   = 'wgts'
     genome = 'GRCh38_hmf'
 
-    ref_data_virusbreakenddb_path = 'https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/oncoanalyser/test_data/reference_data/virusbreakend/virusbreakenddb_test.tar.gz'
+    ref_data_virusbreakenddb_path = 'https://pub-349bcb8decb44bf7acbddf90b270a061.r2.dev/virusbreakend/virusbreakenddb_test-24.04.0.tar.gz'
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -20,10 +20,6 @@ params {
     config_profile_name        = 'Test profile'
     config_profile_description = 'Minimal test dataset to check pipeline function'
 
-    // Defined here to be accessible within a workflow script; downloaded manually prior to process
-    // execution.
-    validationSchemaIgnoreParams = 'genomes,hmf_data_paths,panel_data_paths'
-
     // NOTE(SW): incompatible with GHA given size of reference data
     // Limit resources so that this can run on GitHub Actions
     max_cpus   = 1

--- a/conf/test.config
+++ b/conf/test.config
@@ -20,17 +20,19 @@ params {
     config_profile_name        = 'Test profile'
     config_profile_description = 'Minimal test dataset to check pipeline function'
 
-    // NOTE(SW): incompatible with GHA given size of reference data
+    // NOTE(SW): incompatible with GHA given size of reference data, STAR align requires ~30 GB memory
     // Limit resources so that this can run on GitHub Actions
     max_cpus   = 1
-    max_memory = '8.GB'
+    max_memory = '30.GB'
     max_time   = '6.h'
 
     // Input data
     input = 'https://pub-349bcb8decb44bf7acbddf90b270a061.r2.dev/simulated_reads/24.0/samplesheets/fastq_eval.subject_a-subject_b.wgts.tndna_trna.1.csv'
 
+    // Reference data
+    ref_data_virusbreakenddb_path = 'https://pub-349bcb8decb44bf7acbddf90b270a061.r2.dev/virusbreakend/virusbreakenddb_test-24.04.0.tar.gz'
+
+    // Analysis config
     mode   = 'wgts'
     genome = 'GRCh38_hmf'
-
-    ref_data_virusbreakenddb_path = 'https://pub-349bcb8decb44bf7acbddf90b270a061.r2.dev/virusbreakend/virusbreakenddb_test-24.04.0.tar.gz'
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -23,6 +23,7 @@ params {
     // Input data for full size test
     input = 'https://pub-349bcb8decb44bf7acbddf90b270a061.r2.dev/simulated_reads/24.0/samplesheets/fastq_eval.subject_a-subject_b.wgts.tndna_trna.1.csv'
 
+    // Analysis config
     mode   = 'wgts'
     genome = 'GRCh38_hmf'
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -10,15 +10,19 @@
 ----------------------------------------------------------------------------------------
 */
 
+process {
+    withName: 'PURPLE' {
+        ext.args = '-min_purity 1 -max_purity 1 -min_ploidy 2 -max_ploidy 2'
+    }
+}
+
 params {
     config_profile_name        = 'Full test profile'
     config_profile_description = 'Full test dataset to check pipeline function'
 
     // Input data for full size test
-    // TODO nf-core: Specify the paths to your full test data ( on nf-core/test-datasets or directly in repositories, e.g. SRA)
-    // TODO nf-core: Give any required params for the test so that command line flags are not needed
-    input = params.pipelines_testdata_base_path + 'viralrecon/samplesheet/samplesheet_full_illumina_amplicon.csv'
+    input = 'https://pub-349bcb8decb44bf7acbddf90b270a061.r2.dev/simulated_reads/24.0/samplesheets/fastq_eval.subject_a-subject_b.wgts.tndna_trna.1.csv'
 
-    // Genome references
-    genome = 'R64-1-1'
+    mode   = 'wgts'
+    genome = 'GRCh38_hmf'
 }

--- a/conf/test_stub.config
+++ b/conf/test_stub.config
@@ -14,10 +14,6 @@ params {
     config_profile_name        = 'Stub test profile'
     config_profile_description = 'Stub test dataset to check pipeline function'
 
-    // Defined here to be accessible within a workflow script; downloaded manually prior to process
-    // execution.
-    validationSchemaIgnoreParams = 'genomes,hmf_data_paths,panel_data_paths'
-
     // Limit resources so that this can run on GitHub Actions
     max_cpus   = 1
     max_memory = '8.GB'


### PR DESCRIPTION
- update standard nf-core pipeline tests to use simulated data
- the simulated data is made available through the `umccr-oncoanalyser-testdata` Cloudflare R2 bucket