### PR TITLE
Rename bwa-mem2 index variables

### DIFF
--- a/conf/hmf_genomes.config
+++ b/conf/hmf_genomes.config
@@ -10,20 +10,20 @@
 params {
     genomes {
         'GRCh37_hmf' {
-            fasta           = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/Homo_sapiens.GRCh37.GATK.illumina.fasta"
-            fai             = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/samtools_index/1.16/Homo_sapiens.GRCh37.GATK.illumina.fasta.fai"
-            dict            = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/samtools_index/1.16/Homo_sapiens.GRCh37.GATK.illumina.fasta.dict"
-            bwa_index       = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.1/bwa_index/2.2.1.tar.gz"
-            gridss_index    = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.1/gridss_index/2.13.2.tar.gz"
-            star_index      = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/star_index/gencode_19/2.7.3a.tar.gz"
+            fasta         = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/Homo_sapiens.GRCh37.GATK.illumina.fasta"
+            fai           = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/samtools_index/1.16/Homo_sapiens.GRCh37.GATK.illumina.fasta.fai"
+            dict          = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/samtools_index/1.16/Homo_sapiens.GRCh37.GATK.illumina.fasta.dict"
+            bwamem2_index = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.1/bwa-mem2_index/2.2.1.tar.gz"
+            gridss_index  = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.1/gridss_index/2.13.2.tar.gz"
+            star_index    = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/star_index/gencode_19/2.7.3a.tar.gz"
         }
         'GRCh38_hmf' {
-            fasta           = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna"
-            fai             = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/samtools_index/1.16/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.fai"
-            dict            = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/samtools_index/1.16/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.dict"
-            bwa_index       = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.1/bwa_index/2.2.1.tar.gz"
-            gridss_index    = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.1/gridss_index/2.13.2.tar.gz"
-            star_index      = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/star_index/gencode_38/2.7.3a.tar.gz"
+            fasta         = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna"
+            fai           = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/samtools_index/1.16/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.fai"
+            dict          = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/samtools_index/1.16/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.dict"
+            bwamem2_index = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.1/bwa-mem2_index/2.2.1.tar.gz"
+            gridss_index  = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.1/gridss_index/2.13.2.tar.gz"
+            star_index    = "https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/star_index/gencode_38/2.7.3a.tar.gz"
         }
     }
 }

--- a/conf/test_stub.config
+++ b/conf/test_stub.config
@@ -26,12 +26,12 @@ params {
     genomes {
 
         'GRCh38_hmf' {
-            fasta           = "temp/GRCh38.fasta"
-            fai             = "temp/GRCh38.fai"
-            dict            = "temp/GRCh38.dict"
-            bwa_index       = "temp/GRCh38_bwa-mem2_index/"
-            gridss_index    = "temp/GRCh38_gridss_index/"
-            star_index      = "temp/GRCh38_star_index/"
+            fasta         = "temp/GRCh38.fasta"
+            fai           = "temp/GRCh38.fai"
+            dict          = "temp/GRCh38.dict"
+            bwamem2_index = "temp/GRCh38_bwa-mem2_index/"
+            gridss_index  = "temp/GRCh38_gridss_index/"
+            star_index    = "temp/GRCh38_star_index/"
         }
 
     }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -334,7 +334,7 @@ params {
             fasta           = "/path/to/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna"
             fai             = "/path/to/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.fai"
             dict            = "/path/to/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.dict"
-            bwa_index       = "/path/to/bwa-mem2_index/"
+            bwa-mem2_index  = "/path/to/bwa-mem2_index/"
             gridss_index    = "/path/to/gridss_index/"
             star_index      = "/path/to/star_index/"
         }
@@ -357,7 +357,7 @@ _GRCh37 genome (Hartwig) [`GRCh37_hmf`]_
 | FASTA                | [Homo_sapiens.GRCh37.GATK.illumina.fasta](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/Homo_sapiens.GRCh37.GATK.illumina.fasta)                               |
 | FASTA index          | [Homo_sapiens.GRCh37.GATK.illumina.fasta.fai](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/samtools_index/1.16/Homo_sapiens.GRCh37.GATK.illumina.fasta.fai)   |
 | FASTA seq dictionary | [Homo_sapiens.GRCh37.GATK.illumina.fasta.dict](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/samtools_index/1.16/Homo_sapiens.GRCh37.GATK.illumina.fasta.dict) |
-| bwa-mem2 index       | [bwa_index/2.2.1.tar.gz](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.1/bwa_index/2.2.1.tar.gz)                                                                 |
+| bwa-mem2 index       | [bwa-mem2_index/2.2.1.tar.gz](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.1/bwa-mem2_index/2.2.1.tar.gz)                                                       |
 | GRIDSS index         | [gridss_index/2.13.2.tar.gz](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.1/gridss_index/2.13.2.tar.gz)                                                         |
 | STAR index           | [star_index/gencode_19/2.7.3a.tar.gz](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/star_index/gencode_19/2.7.3a.tar.gz)                                       |
 
@@ -368,7 +368,7 @@ _GRCh38 genome (Hartwig) [`GRCh38_hmf`]_
 | FASTA                | [GCA_000001405.15_GRCh38_no_alt_analysis_set.fna](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna)                               |
 | FASTA index          | [GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.fai](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/samtools_index/1.16/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.fai)   |
 | FASTA seq dictionary | [GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.dict](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/samtools_index/1.16/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.dict) |
-| bwa-mem2 index       | [bwa_index/2.2.1.tar.gz](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.1/bwa_index/2.2.1.tar.gz)                                                                                 |
+| bwa-mem2 index       | [bwa-mem2_index/2.2.1.tar.gz](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.1/bwa-mem2_index/2.2.1.tar.gz)                                                                       |
 | GRIDSS index         | [gridss_index/2.13.2.tar.gz](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.1/gridss_index/2.13.2.tar.gz)                                                                         |
 | STAR index           | [star_index/gencode_38/2.7.3a.tar.gz](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh38_hmf/24.0/star_index/gencode_38/2.7.3a.tar.gz)                                                       |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -334,7 +334,7 @@ params {
             fasta           = "/path/to/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna"
             fai             = "/path/to/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.fai"
             dict            = "/path/to/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.dict"
-            bwa-mem2_index  = "/path/to/bwa-mem2_index/"
+            bwamem2_index   = "/path/to/bwa-mem2_index/"
             gridss_index    = "/path/to/gridss_index/"
             star_index      = "/path/to/star_index/"
         }

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -197,12 +197,13 @@ class Utils {
 
         def fps = [
             params.ref_data_genome_alt,
-            params.ref_data_genome_bwa_index,
+            params.ref_data_genome_bwamem2_index,
             params.ref_data_genome_dict,
             params.ref_data_genome_fai,
             params.ref_data_genome_fasta,
             params.ref_data_genome_gridss_index,
             params.ref_data_genome_gtf,
+            params.ref_data_genome_star_index,
             params.ref_data_virusbreakenddb_path,
         ]
 
@@ -323,7 +324,7 @@ class Utils {
         def has_alt_contigs = params.genome_type == 'alt'
 
         // Ensure that custom genomes with ALT contigs that need indexes built have the required .alt file
-        def has_bwa_indexes = (params.ref_data_genome_bwa_index && params.ref_data_genome_gridss_index)
+        def has_bwa_indexes = (params.ref_data_genome_bwamem2_index && params.ref_data_genome_gridss_index)
         def has_alt_file = params.containsKey('ref_data_genome_alt') && params.ref_data_genome_alt
         def run_bwa_or_gridss_index = run_config.stages.alignment && run_config.has_dna_fastq && !has_bwa_indexes
 

--- a/main.nf
+++ b/main.nf
@@ -31,12 +31,12 @@ include { getGenomeAttribute } from './subworkflows/local/utils_nfcore_oncoanaly
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-params.ref_data_genome_fasta           = getGenomeAttribute('fasta')
-params.ref_data_genome_fai             = getGenomeAttribute('fai')
-params.ref_data_genome_dict            = getGenomeAttribute('dict')
-params.ref_data_genome_bwa_index       = getGenomeAttribute('bwa_index')
-params.ref_data_genome_gridss_index    = getGenomeAttribute('gridss_index')
-params.ref_data_genome_star_index      = getGenomeAttribute('star_index')
+params.ref_data_genome_fasta         = getGenomeAttribute('fasta')
+params.ref_data_genome_fai           = getGenomeAttribute('fai')
+params.ref_data_genome_dict          = getGenomeAttribute('dict')
+params.ref_data_genome_bwamem2_index = getGenomeAttribute('bwamem2_index')
+params.ref_data_genome_gridss_index  = getGenomeAttribute('gridss_index')
+params.ref_data_genome_star_index    = getGenomeAttribute('star_index')
 
 WorkflowMain.setParamsDefaults(params, log)
 WorkflowMain.validateParams(params, log)

--- a/modules/local/bwa-mem2/mem/main.nf
+++ b/modules/local/bwa-mem2/mem/main.nf
@@ -10,7 +10,7 @@ process BWAMEM2_ALIGN {
     input:
     tuple val(meta), path(reads_fwd), path(reads_rev)
     path genome_fasta
-    path genome_bwa_index
+    path genome_bwamem2_index
 
     output:
     tuple val(meta), path('*.bam'), path('*.bai'), emit: bam
@@ -28,7 +28,7 @@ process BWAMEM2_ALIGN {
     def output_fn = meta.split ? "${meta.split}.${meta.sample_id}.${meta.read_group}.bam" : "${meta.sample_id}.${meta.read_group}.bam"
 
     """
-    ln -fs \$(find -L ${genome_bwa_index} -type f) ./
+    ln -fs \$(find -L ${genome_bwamem2_index} -type f) ./
 
     bwa-mem2 mem \\
         ${args} \\

--- a/modules/local/bwa-mem2/mem/meta.yml
+++ b/modules/local/bwa-mem2/mem/meta.yml
@@ -29,9 +29,9 @@ input:
       type: file
       description: Reference genome assembly FASTA file
       pattern: "*.{fa,fasta}"
-  - genome_bwa_index:
+  - genome_bwamem2_index:
       type: directory
-      description: bwa-mem1 index directory
+      description: bwa-mem2 index directory
 output:
   - meta:
       type: map

--- a/modules/local/custom/lilac_extract_and_index_contig/main.nf
+++ b/modules/local/custom/lilac_extract_and_index_contig/main.nf
@@ -15,7 +15,7 @@ process CUSTOM_EXTRACTCONTIG {
 
     output:
     path "*extracted.fa"  , emit: contig
-    path "*extracted.fa.*", emit: bwa_index
+    path "*extracted.fa.*", emit: bwamem2_index
     path 'versions.yml'   , emit: versions
 
     when:

--- a/nextflow.config
+++ b/nextflow.config
@@ -78,7 +78,7 @@ params {
         'panel_data_paths',
         'ref_data',
         'ref_data_genome_alt',
-        'ref_data_genome_bwa_index',
+        'ref_data_genome_bwamem2_index',
         'ref_data_genome_dict',
         'ref_data_genome_fai',
         'ref_data_genome_fasta',

--- a/subworkflows/local/lilac_calling/main.nf
+++ b/subworkflows/local/lilac_calling/main.nf
@@ -131,7 +131,7 @@ workflow LILAC_CALLING {
         REALIGNREADS(
             SLICEBAM.out.bam,
             EXTRACTCONTIG.out.contig,
-            EXTRACTCONTIG.out.bwa_index,
+            EXTRACTCONTIG.out.bwamem2_index,
         )
 
         ch_versions = ch_versions.mix(REALIGNREADS.out.versions)

--- a/subworkflows/local/prepare_reference/main.nf
+++ b/subworkflows/local/prepare_reference/main.nf
@@ -55,28 +55,28 @@ workflow PREPARE_REFERENCE {
     //
     // Set bwa-mem2 index, unpack or create if required
     //
-    ch_genome_bwa_index = Channel.empty()
+    ch_genome_bwamem2_index = Channel.empty()
     if (run_config.has_dna && run_config.stages.alignment) {
-        if (!params.ref_data_genome_bwa_index) {
+        if (!params.ref_data_genome_bwamem2_index) {
 
             BWAMEM2_INDEX(
                 ch_genome_fasta,
                 params.ref_data_genome_alt ? file(params.ref_data_genome_alt) : [],
             )
-            ch_genome_bwa_index = BWAMEM2_INDEX.out.index
+            ch_genome_bwamem2_index = BWAMEM2_INDEX.out.index
             ch_versions = ch_versions.mix(BWAMEM2_INDEX.out.versions)
 
-        } else if (params.ref_data_genome_bwa_index.endsWith('.tar.gz')) {
+        } else if (params.ref_data_genome_bwamem2_index.endsWith('.tar.gz')) {
 
-            ch_genome_bwa_index_inputs = Channel.fromPath(params.ref_data_genome_bwa_index)
+            ch_genome_bwamem2_index_inputs = Channel.fromPath(params.ref_data_genome_bwamem2_index)
                 .map { [[id: "bwa-mem2_index_${it.name.replaceAll('\\.tar\\.gz$', '')}"], it] }
 
-            DECOMP_BWAMEM2_INDEX(ch_genome_bwa_index_inputs)
-            ch_genome_bwa_index = DECOMP_BWAMEM2_INDEX.out.dir
+            DECOMP_BWAMEM2_INDEX(ch_genome_bwamem2_index_inputs)
+            ch_genome_bwamem2_index = DECOMP_BWAMEM2_INDEX.out.dir
 
         } else {
 
-            ch_genome_bwa_index = getRefFileChannel('ref_data_genome_bwa_index')
+            ch_genome_bwamem2_index = getRefFileChannel('ref_data_genome_bwamem2_index')
 
         }
     }
@@ -235,7 +235,7 @@ workflow PREPARE_REFERENCE {
                 ch_genome_fasta,
                 ch_genome_fai,
                 ch_genome_dict,
-                ch_genome_bwa_index,
+                ch_genome_bwamem2_index,
                 ch_genome_gridss_index,
                 ch_genome_star_index,
                 ch_virusbreakenddb,
@@ -258,19 +258,19 @@ workflow PREPARE_REFERENCE {
     }
 
     emit:
-    genome_fasta        = ch_genome_fasta.first()        // path: genome_fasta
-    genome_fai          = ch_genome_fai.first()          // path: genome_fai
-    genome_dict         = ch_genome_dict.first()         // path: genome_dict
-    genome_bwa_index    = ch_genome_bwa_index.first()    // path: genome_bwa_index
-    genome_gridss_index = ch_genome_gridss_index.first() // path: genome_gridss_index
-    genome_star_index   = ch_genome_star_index.first()   // path: genome_star_index
-    genome_version      = ch_genome_version              // val:  genome_version
+    genome_fasta         = ch_genome_fasta.first()         // path: genome_fasta
+    genome_fai           = ch_genome_fai.first()           // path: genome_fai
+    genome_dict          = ch_genome_dict.first()          // path: genome_dict
+    genome_bwamem2_index = ch_genome_bwamem2_index.first() // path: genome_bwa-mem2_index
+    genome_gridss_index  = ch_genome_gridss_index.first()  // path: genome_gridss_index
+    genome_star_index    = ch_genome_star_index.first()    // path: genome_star_index
+    genome_version       = ch_genome_version               // val:  genome_version
 
-    virusbreakenddb     = ch_virusbreakenddb.first()     // path: VIRUSBreakend database
-    hmf_data            = ch_hmf_data                    // map:  HMF data paths
-    panel_data          = ch_panel_data                  // map:  Panel data paths
+    virusbreakenddb      = ch_virusbreakenddb.first()      // path: VIRUSBreakend database
+    hmf_data             = ch_hmf_data                     // map:  HMF data paths
+    panel_data           = ch_panel_data                   // map:  Panel data paths
 
-    versions            = ch_versions                    // channel: [ versions.yml ]
+    versions             = ch_versions                     // channel: [ versions.yml ]
 }
 
 def getRefFileChannel(key) {

--- a/workflows/targeted.nf
+++ b/workflows/targeted.nf
@@ -114,7 +114,7 @@ workflow TARGETED {
         READ_ALIGNMENT_DNA(
             ch_inputs,
             ref_data.genome_fasta,
-            ref_data.genome_bwa_index,
+            ref_data.genome_bwamem2_index,
             params.max_fastq_records,
         )
 

--- a/workflows/wgts.nf
+++ b/workflows/wgts.nf
@@ -123,7 +123,7 @@ workflow WGTS {
         READ_ALIGNMENT_DNA(
             ch_inputs,
             ref_data.genome_fasta,
-            ref_data.genome_bwa_index,
+            ref_data.genome_bwamem2_index,
             params.max_fastq_records,
         )
 


### PR DESCRIPTION
- more clearly differentiates bwa-mem2 and BWA indexes since these are two distinct pieces of software
- adjusted remote paths accordingly; edited existing `24.1` version since it is not yet tied to an oncoanalyser release
- also included: STAR index placeholder creation for stub runs