### PR TITLE
Do not split FASTQs during tests

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -33,6 +33,7 @@ params {
     ref_data_virusbreakenddb_path = 'https://pub-349bcb8decb44bf7acbddf90b270a061.r2.dev/virusbreakend/virusbreakenddb_test-24.04.0.tar.gz'
 
     // Analysis config
-    mode   = 'wgts'
-    genome = 'GRCh38_hmf'
+    mode              = 'wgts'
+    genome            = 'GRCh38_hmf'
+    max_fastq_records = 0
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -24,6 +24,7 @@ params {
     input = 'https://pub-349bcb8decb44bf7acbddf90b270a061.r2.dev/simulated_reads/24.0/samplesheets/fastq_eval.subject_a-subject_b.wgts.tndna_trna.1.csv'
 
     // Analysis config
-    mode   = 'wgts'
-    genome = 'GRCh38_hmf'
+    mode              = 'wgts'
+    genome            = 'GRCh38_hmf'
+    max_fastq_records = 0
 }

--- a/conf/test_stub.config
+++ b/conf/test_stub.config
@@ -41,7 +41,7 @@ params {
     ref_data_panel_data_path      = "temp/panel_bundle/tso500_38/"
 
     // Analysis config
-    mode   = 'wgts'
-    genome = 'GRCh38_hmf'
+    mode                     = 'wgts'
+    genome                   = 'GRCh38_hmf'
     create_stub_placeholders = true
 }


### PR DESCRIPTION
- avoid needlessly splitting FASTQs in tests by setting `max_fastq_records` in relevant test profiles