### PR TITLE
Fix display of the ORANGE report screencap on the nf-core website

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ custom panels with externally-generated normalisation data.
 The key analysis results for each sample are summarised and presented in an ORANGE report (summary page excerpt shown
 below from _[COLO829_wgts.orange_report.pdf](https://pub-29f2e5b2b7384811bdbbcba44f8b5083.r2.dev/oncoanalyser/other/example_report/COLO829_wgts.orange_report.pdf)_):
 
-<p align='center'><img width='750' src='docs/images/COLO829_wgts.orange_report.summary_section.png'></p>
+<p align="center"><img width="750" src="docs/images/COLO829_wgts.orange_report.summary_section.png"></p>
 
 For detailed information on each component of the Hartwig workflow, please refer to
 [hartwigmedical/hmftools](https://github.com/hartwigmedical/hmftools/).


### PR DESCRIPTION
- the image of the ORANGE screencap example in the GitHub README.md is broken on the nf-core website
- breakage introduced by the relative link path not being converted to an absolute link path during website build
- caused by the relevant regex used in octokit recognising double but not single quotation marks ([link](https://github.com/nf-core/website/blob/cf6fb8886321aa24024c2e7ac632627329088138/src/components/octokit.js#L47-L54))
- this PR resolves by swapping single quotation marks to double quotation marks for the corresponding HTML tags