### PR TITLE
Make README.md admonition compatible with website

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,7 @@ nextflow run nf-core/oncoanalyser \
 ```
 
 > [!WARNING]
-> Please provide pipeline parameters via the CLI or Nextflow `-params-file` option. Custom config files including those provided by the `-c` Nextflow option can be used to provide any configuration _**except for parameters**_;
-> see [docs](https://nf-co.re/usage/configuration#custom-configuration-files).
+> Please provide pipeline parameters via the CLI or Nextflow `-params-file` option. Custom config files including those provided by the `-c` Nextflow option can be used to provide any configuration _**except for parameters**_; see [docs](https://nf-co.re/usage/configuration#custom-configuration-files).
 
 For more details and further functionality, please refer to the [usage documentation](https://nf-co.re/oncoanalyser/usage) and the [parameter documentation](https://nf-co.re/oncoanalyser/parameters).
 


### PR DESCRIPTION
- GH style admonition in README.md doesn't render correctly on website
- retain but adjust GH style admonition to correct website rendering
- see https://github.com/nf-core/oncoanalyser/pull/39 for more details on current constraints