### PR TITLE
Fix conditional creation of bwa-mem2 index

### DIFF
--- a/subworkflows/local/prepare_reference/main.nf
+++ b/subworkflows/local/prepare_reference/main.nf
@@ -56,7 +56,7 @@ workflow PREPARE_REFERENCE {
     // Set bwa-mem2 index, unpack or create if required
     //
     ch_genome_bwamem2_index = Channel.empty()
-    if (run_config.has_dna && run_config.stages.alignment) {
+    if (run_config.has_dna_fastq && run_config.stages.alignment) {
         if (!params.ref_data_genome_bwamem2_index) {
 
             BWAMEM2_INDEX(


### PR DESCRIPTION
- the bwa-mem2 index should only be created if one is not provided and DNA alignment will be run
- currently the conditional check doesn't differentiate FASTQ, BAM DNA inputs 
- hence, bwa-mem2 index creation is incorrectly triggered when just DNA BAM inputs are provided
- the change in this PR prevents unnecessary bwa-mem2 index creation 