### PR TITLE
Bump MarkDups 1.1.5 to Bioconda build hdfd78af_1

### DIFF
--- a/modules/local/markdups/environment.yml
+++ b/modules/local/markdups/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::hmftools-mark-dups=1.1.5
+  - bioconda::hmftools-mark-dups=1.1.5=hdfd78af_1

--- a/modules/local/markdups/main.nf
+++ b/modules/local/markdups/main.nf
@@ -3,8 +3,8 @@ process MARKDUPS {
     label 'process_medium'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/hmftools-mark-dups:1.1.5--hdfd78af_0' :
-        'biocontainers/hmftools-mark-dups:1.1.5--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/hmftools-mark-dups:1.1.5--hdfd78af_1' :
+        'biocontainers/hmftools-mark-dups:1.1.5--hdfd78af_1' }"
 
     input:
     tuple val(meta), path(bams), path(bais)


### PR DESCRIPTION
- use rebuilt MarkDups 1.1.5 package with Sambamba fix, see:
  - https://github.com/bioconda/bioconda-recipes/pull/48085