### PR TITLE
Bump MarkDups to 1.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ in the below table.
 
 ## Known issues
 
-- MarkDups may encounter a fatal error processing hard-clipped supplementary alignments ([#37](https://github.com/nf-core/oncoanalyser/issues/37))
+There are currently no known issues.
 
 ## Credits
 

--- a/modules/local/markdups/main.nf
+++ b/modules/local/markdups/main.nf
@@ -3,8 +3,8 @@ process MARKDUPS {
     label 'process_medium'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/hmftools-mark-dups:1.1.5--hdfd78af_1' :
-        'biocontainers/hmftools-mark-dups:1.1.5--hdfd78af_1' }"
+        'https://depot.galaxyproject.org/singularity/hmftools-mark-dups:1.1.7--hdfd78af_0' :
+        'biocontainers/hmftools-mark-dups:1.1.7--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(bams), path(bais)


### PR DESCRIPTION
- bump MarkDups to 1.1.7
- update README.md 'Known Issues'
- resolves #37 