### PR TITLE
Fix directory shadowing symlinks

### DIFF
--- a/modules/local/svprep/assemble/main.nf
+++ b/modules/local/svprep/assemble/main.nf
@@ -58,7 +58,7 @@ process GRIDSS_ASSEMBLE {
             # NOTE(SW): ideally we would get the relative path using the --relative-to but this is only
             # supported for GNU realpath and fails for others such as BusyBox, which is used in Biocontainers
             symlinkpath=\$(realpath \${filepath_src})
-            ln -s \${symlinkpath} \${filepath_dst};
+            ln -s "\${symlinkpath}" \${filepath_dst};
         done
         if [[ -L "\${src##*/}" ]]; then
             rm "\${src}"

--- a/modules/local/svprep/call/main.nf
+++ b/modules/local/svprep/call/main.nf
@@ -58,7 +58,7 @@ process GRIDSS_CALL {
             # NOTE(SW): ideally we would get the relative path using the --relative-to but this is only
             # supported for GNU realpath and fails for others such as BusyBox, which is used in Biocontainers
             symlinkpath=\$(realpath \${filepath_src})
-            ln -s \${symlinkpath} \${filepath_dst};
+            ln -s "\${symlinkpath}" \${filepath_dst};
         done
         if [[ -L "\${src##*/}" ]]; then
             rm "\${src}"


### PR DESCRIPTION
- when oncoanalyser runs under a directory path containing a space, directory shadowing fails causing a pipeline crash
- this bug impacts both the GRIDSS assemble and GRIDSS call process
- changes made in this PR allow proper handling of paths containing spaces for directory shadowing