### PR TITLE
symlink specific gridss index files

### DIFF
--- a/modules/local/svprep/assemble/main.nf
+++ b/modules/local/svprep/assemble/main.nf
@@ -69,7 +69,7 @@ process GRIDSS_ASSEMBLE {
     done
 
     # Symlink indices next to assembly FASTA
-    ln -s \$(find -L ${genome_gridss_index} -regex '.*\.\(amb\|ann\|pac\|gridsscache\|sa\|bwt\|img\|alt\)') ./
+    ln -s \$(find -L ${genome_gridss_index} -regex '.*\\.\\(amb\\|ann\\|pac\\|gridsscache\\|sa\\|bwt\\|img\\|alt\\)') ./
 
     # Run
     gridss_svprep \\

--- a/modules/local/svprep/assemble/main.nf
+++ b/modules/local/svprep/assemble/main.nf
@@ -69,7 +69,7 @@ process GRIDSS_ASSEMBLE {
     done
 
     # Symlink indices next to assembly FASTA
-    ln -s \$(find -L ${genome_gridss_index} -regex '.*\.\(amb\|ann\|pac\|gridsscache\|sa\|bwa\|img\|alt\)') ./
+    ln -s \$(find -L ${genome_gridss_index} -regex '.*\.\(amb\|ann\|pac\|gridsscache\|sa\|bwt\|img\|alt\)') ./
 
     # Run
     gridss_svprep \\

--- a/modules/local/svprep/assemble/main.nf
+++ b/modules/local/svprep/assemble/main.nf
@@ -69,7 +69,7 @@ process GRIDSS_ASSEMBLE {
     done
 
     # Symlink indices next to assembly FASTA
-    ln -s \$(find -L ${genome_gridss_index} -type f) ./
+    ln -s \$(find -L ${genome_gridss_index} -regex '.*\.\(amb\|ann\|pac\|gridsscache\|sa\|bwa\|img\|alt\)') ./
 
     # Run
     gridss_svprep \\

--- a/modules/local/svprep/call/main.nf
+++ b/modules/local/svprep/call/main.nf
@@ -67,7 +67,7 @@ process GRIDSS_CALL {
     shadow_input_directory ${assemble_dir}
 
     # Symlink indices next to assembly FASTA
-    ln -s \$(find -L ${genome_gridss_index} -regex '.*\.\(amb\|ann\|pac\|gridsscache\|sa\|bwt\|img\|alt\)') ./
+    ln -s \$(find -L ${genome_gridss_index} -regex '.*\\.\\(amb\\|ann\\|pac\\|gridsscache\\|sa\\|bwt\\|img\\|alt\\)') ./
 
     # Run
     gridss_svprep \\

--- a/modules/local/svprep/call/main.nf
+++ b/modules/local/svprep/call/main.nf
@@ -67,7 +67,7 @@ process GRIDSS_CALL {
     shadow_input_directory ${assemble_dir}
 
     # Symlink indices next to assembly FASTA
-    ln -s \$(find -L ${genome_gridss_index} -regex '.*\.\(amb\|ann\|pac\|gridsscache\|sa\|bwa\|img\|alt\)') ./
+    ln -s \$(find -L ${genome_gridss_index} -regex '.*\.\(amb\|ann\|pac\|gridsscache\|sa\|bwt\|img\|alt\)') ./
 
     # Run
     gridss_svprep \\

--- a/modules/local/svprep/call/main.nf
+++ b/modules/local/svprep/call/main.nf
@@ -67,7 +67,7 @@ process GRIDSS_CALL {
     shadow_input_directory ${assemble_dir}
 
     # Symlink indices next to assembly FASTA
-    ln -s \$(find -L ${genome_gridss_index} -type f) ./
+    ln -s \$(find -L ${genome_gridss_index} -regex '.*\.\(amb\|ann\|pac\|gridsscache\|sa\|bwa\|img\|alt\)') ./
 
     # Run
     gridss_svprep \\

--- a/modules/local/svprep/preprocess/main.nf
+++ b/modules/local/svprep/preprocess/main.nf
@@ -29,7 +29,7 @@ process GRIDSS_PREPROCESS {
 
     """
     # Symlink indices next to assembly FASTA
-    ln -s \$(find -L ${genome_gridss_index} -regex '.*\.\(amb\|ann\|pac\|gridsscache\|sa\|bwa\|img\|alt\)') ./
+    ln -s \$(find -L ${genome_gridss_index} -regex '.*\.\(amb\|ann\|pac\|gridsscache\|sa\|bwt\|img\|alt\)') ./
 
     gridss_svprep \\
         ${args} \\

--- a/modules/local/svprep/preprocess/main.nf
+++ b/modules/local/svprep/preprocess/main.nf
@@ -29,7 +29,7 @@ process GRIDSS_PREPROCESS {
 
     """
     # Symlink indices next to assembly FASTA
-    ln -s \$(find -L ${genome_gridss_index} -regex '.*\.\(amb\|ann\|pac\|gridsscache\|sa\|bwt\|img\|alt\)') ./
+    ln -s \$(find -L ${genome_gridss_index} -regex '.*\\.\\(amb\\|ann\\|pac\\|gridsscache\\|sa\\|bwt\\|img\\|alt\\)') ./
 
     gridss_svprep \\
         ${args} \\

--- a/modules/local/svprep/preprocess/main.nf
+++ b/modules/local/svprep/preprocess/main.nf
@@ -29,7 +29,7 @@ process GRIDSS_PREPROCESS {
 
     """
     # Symlink indices next to assembly FASTA
-    ln -s \$(find -L ${genome_gridss_index} -type f) ./
+    ln -s \$(find -L ${genome_gridss_index} -regex '.*\.\(amb\|ann\|pac\|gridsscache\|sa\|bwa\|img\|alt\)') ./
 
     gridss_svprep \\
         ${args} \\

--- a/modules/local/virusbreakend/main.nf
+++ b/modules/local/virusbreakend/main.nf
@@ -29,7 +29,7 @@ process VIRUSBREAKEND {
 
     """
     # Symlink indices next to assembly FASTA
-    ln -s \$(find -L ${genome_gridss_index} -type f) ./
+    ln -s \$(find -L ${genome_gridss_index} -type f -name *.gridsscache -o -name *.img) ./
 
     virusbreakend \\
         ${args} \\

--- a/modules/local/virusbreakend/main.nf
+++ b/modules/local/virusbreakend/main.nf
@@ -29,7 +29,7 @@ process VIRUSBREAKEND {
 
     """
     # Symlink indices next to assembly FASTA
-    ln -s \$(find -L ${genome_gridss_index} -regex '.*\.\(amb\|ann\|pac\|gridsscache\|sa\|bwa\|img\|alt\)') ./
+    ln -s \$(find -L ${genome_gridss_index} -regex '.*\.\(amb\|ann\|pac\|gridsscache\|sa\|bwt\|img\|alt\)') ./
 
     virusbreakend \\
         ${args} \\

--- a/modules/local/virusbreakend/main.nf
+++ b/modules/local/virusbreakend/main.nf
@@ -29,7 +29,7 @@ process VIRUSBREAKEND {
 
     """
     # Symlink indices next to assembly FASTA
-    ln -s \$(find -L ${genome_gridss_index} -type f -name *.gridsscache -o -name *.img) ./
+    ln -s \$(find -L ${genome_gridss_index} -regex '.*\.\(amb\|ann\|pac\|gridsscache\|sa\|bwa\|img\|alt\)') ./
 
     virusbreakend \\
         ${args} \\

--- a/modules/local/virusbreakend/main.nf
+++ b/modules/local/virusbreakend/main.nf
@@ -29,7 +29,7 @@ process VIRUSBREAKEND {
 
     """
     # Symlink indices next to assembly FASTA
-    ln -s \$(find -L ${genome_gridss_index} -regex '.*\.\(amb\|ann\|pac\|gridsscache\|sa\|bwt\|img\|alt\)') ./
+    ln -s \$(find -L ${genome_gridss_index} -regex '.*\\.\\(amb\\|ann\\|pac\\|gridsscache\\|sa\\|bwt\\|img\\|alt\\)') ./
 
     virusbreakend \\
         ${args} \\


### PR DESCRIPTION
genome_gridss_index folder may contain additional files that are staged by nextflow if they are part of the inputs (e.g. someone might have the .dict file in this folder if they created it via gridss.PrepareReference). This causes an error when we try to symlink the entire contents of the folder. Suggestion: symlink only specific files of interest. 