### PR TITLE
Bump SAGE to 3.4.4

### DIFF
--- a/modules/local/sage/append/main.nf
+++ b/modules/local/sage/append/main.nf
@@ -4,8 +4,8 @@ process SAGE_APPEND {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/hmftools-sage:3.4.3--hdfd78af_0' :
-        'biocontainers/hmftools-sage:3.4.3--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/hmftools-sage:3.4.4--hdfd78af_0' :
+        'biocontainers/hmftools-sage:3.4.4--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(vcf), path(bam), path(bai)

--- a/modules/local/sage/germline/main.nf
+++ b/modules/local/sage/germline/main.nf
@@ -4,8 +4,8 @@ process SAGE_GERMLINE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/hmftools-sage:3.4.3--hdfd78af_0' :
-        'biocontainers/hmftools-sage:3.4.3--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/hmftools-sage:3.4.4--hdfd78af_0' :
+        'biocontainers/hmftools-sage:3.4.4--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(tumor_bam), path(normal_bam), path(tumor_bai), path(normal_bai)

--- a/modules/local/sage/somatic/main.nf
+++ b/modules/local/sage/somatic/main.nf
@@ -6,8 +6,8 @@ process SAGE_SOMATIC {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/hmftools-sage:3.4.3--hdfd78af_0' :
-        'biocontainers/hmftools-sage:3.4.3--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/hmftools-sage:3.4.4--hdfd78af_0' :
+        'biocontainers/hmftools-sage:3.4.4--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(tumor_bam), path(normal_bam), path(tumor_bai), path(normal_bai)


### PR DESCRIPTION
- update to [SAGE 3.4.4](https://github.com/hartwigmedical/hmftools/releases/tag/sage-v3.4.4)
- resolves extended runtimes when using reference genomes with many contigs (e.g. GRCh38 with ALTs)