### PR TITLE
Allow RNA BAM from samplesheet as LILAC input

### DIFF
--- a/subworkflows/local/lilac_calling/main.nf
+++ b/subworkflows/local/lilac_calling/main.nf
@@ -193,8 +193,8 @@ workflow LILAC_CALLING {
                 nbai_dna,
                 tbam_dna,
                 tbai_dna,
-                tbam_rna,
-                tbai_rna,
+                Utils.selectCurrentOrExisting(tbam_rna, meta, Constants.INPUT.BAM_RNA_TUMOR),
+                Utils.selectCurrentOrExisting(tbai_rna, meta, Constants.INPUT.BAI_RNA_TUMOR),
                 Utils.selectCurrentOrExisting(purple_dir, meta, Constants.INPUT.PURPLE_DIR),
             ]
         }


### PR DESCRIPTION
- previously LILAC would only accept RNA BAMs from the RNA alignment subworkflow
- this PR allows users to also provide RNA BAMs in the samplesheet for LILAC