### PR TITLE
Fix panel parameter validation during pre-flight check

### DIFF
--- a/lib/WorkflowMain.groovy
+++ b/lib/WorkflowMain.groovy
@@ -182,9 +182,9 @@ class WorkflowMain {
 
                 def panels = Constants.PANELS_DEFINED.join('\n    - ')
                 log.error "\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
-                    "  A panel is required to be set using the --panel CLI argument or in a \n" +
-                    "  configuration file.\n" +
-                    "  Currently, the available panels are:\n" +
+                    "  A panel is required to be set using the --panel CLI argument or in a\n" +
+                    "  configuration file when running in targeted mode.\n" +
+                    "  Currently, the available built-in panels are:\n" +
                     "    - ${panels}\n" +
                     "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
                 Nextflow.exit(1)

--- a/lib/WorkflowMain.groovy
+++ b/lib/WorkflowMain.groovy
@@ -178,7 +178,7 @@ class WorkflowMain {
 
         if (run_mode === Constants.RunMode.TARGETED) {
 
-            if (!params.containsKey('panel')) {
+            if (!params.containsKey('panel') || params.panel === null) {
 
                 def panels = Constants.PANELS_DEFINED.join('\n    - ')
                 log.error "\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +


### PR DESCRIPTION
- when running in targeted mode the panel parameter must be set
- the validation code used to check this did not previously consider null values
- the panel parameter is now correctly identified as unset when it is either absent or set to null
- closes #77 

<!--
# nf-core/oncoanalyser pull request

Many thanks for contributing to nf-core/oncoanalyser!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/oncoanalyser/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/oncoanalyser/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/oncoanalyser _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
