### PR TITLE
Update PAVE somatic command

### DIFF
--- a/modules/local/pave/somatic/main.nf
+++ b/modules/local/pave/somatic/main.nf
@@ -14,8 +14,6 @@ process PAVE_SOMATIC {
     path genome_fai
     path sage_pon
     path pon_artefacts
-    path sage_blocklist_regions
-    path sage_blocklist_sites
     path clinvar_annotations
     path segment_mappability
     path driver_gene_panel
@@ -47,9 +45,6 @@ process PAVE_SOMATIC {
 
     // Targeted mode
     def pon_artefact_arg = pon_artefacts ? "-pon_artefact_file ${pon_artefacts}" : ''
-    def sage_blocklist_regions_arg = sage_blocklist_regions ? "-blacklist_bed ${sage_blocklist_regions}" : ''
-    def sage_blocklist_sites_arg = sage_blocklist_sites ? "-blacklist_vcf ${sage_blocklist_sites}" : ''
-    def clinvar_annotations = clinvar_annotations ? "-clinvar_vcf ${clinvar_annotations}" : ''
 
     """
     pave \\
@@ -62,12 +57,10 @@ process PAVE_SOMATIC {
         -pon_file ${sage_pon} \\
         -pon_filters "${pon_filters}" \\
         ${pon_artefact_arg} \\
-        ${clinvar_annotations} \\
+        -clinvar_vcf ${clinvar_annotations} \\
         -driver_gene_panel ${driver_gene_panel} \\
         -mappability_bed ${segment_mappability} \\
         -ensembl_data_dir ${ensembl_data_resources} \\
-        ${sage_blocklist_regions_arg} \\
-        ${sage_blocklist_sites_arg} \\
         ${gnomad_args} \\
         -read_pass_only \\
         -threads ${task.cpus} \\

--- a/modules/local/pave/somatic/meta.yml
+++ b/modules/local/pave/somatic/meta.yml
@@ -45,14 +45,6 @@ input:
   - pon_artefacts:
       type: file
       description: Taregeted sequencing PON artefacts file (optional)
-  - sage_blocklist_regions:
-      type: file
-      description: SAGE regions blocklist file
-      pattern: "*.{bed}"
-  - sage_blocklist_sites:
-      type: file
-      description: SAGE sites blocklist file
-      pattern: "*.{vcf.gz}"
   - clinvar_annotations:
       type: file
       description: ClinVar annotations VCF file

--- a/subworkflows/local/pave_annotation/main.nf
+++ b/subworkflows/local/pave_annotation/main.nf
@@ -124,20 +124,6 @@ workflow PAVE_ANNOTATION {
             return [meta_pave, sage_vcf, sage_tbi]
         }
 
-    // Set resource files according to run mode
-    // NOTE(SW): required since certain files can be used in germline and somatic depending on mode
-    // but want to avoid duplicating as multiple inputs
-    // NOTE(SW): this pattern should be used only sparingly; implicit config from workflows is prefered
-    sage_blocklist_regions_somatic = sage_blocklist_regions
-    sage_blocklist_sites_somatic = sage_blocklist_sites
-    clinvar_annotations_somatic = clinvar_annotations
-    run_mode = Utils.getEnumFromString(params.mode, Constants.RunMode)
-    if (run_mode === Constants.RunMode.WGTS) {
-        sage_blocklist_regions_somatic = []
-        sage_blocklist_sites_somatic = []
-        clinvar_annotations_somatic = []
-    }
-
     // Run process
     SOMATIC(
         ch_pave_somatic_inputs,
@@ -146,9 +132,7 @@ workflow PAVE_ANNOTATION {
         genome_fai,
         sage_pon,
         pon_artefacts,
-        sage_blocklist_regions_somatic,
-        sage_blocklist_sites_somatic,
-        clinvar_annotations_somatic,
+        clinvar_annotations,
         segment_mappability,
         driver_gene_panel,
         ensembl_data_resources,


### PR DESCRIPTION
- previously the PAVE command followed the Pv5 implementation
- the recommendation is now to run PAVE always with the `-clinvar_vcf` argument
- similarly, the `-blacklist_bed` and `-blacklist_vcf` should now only be used for PAVE germline
- both changes are also recommended irrespective of sequence type (wgts/targeted) or analysis type (tn/to)