### PR TITLE
Add type to ref_data_hla_slice_bed entry in the nextflow_schema.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [dev]
 
+- [96](https://github.com/nf-core/oncoanalyser/pull/96) - Added missing type field to an entry in the nextflow_schema.json
+
 - [95](https://github.com/nf-core/oncoanalyser/pull/95) - Post-release bump
 
 ## [[1.0.0](https://github.com/nf-core/oncoanalyser/releases/tag/1.0.0)] Pied Currawong - 2024-08-26

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -179,6 +179,7 @@
                     "fa_icon": "far fa-file-code"
                 },
                 "ref_data_hla_slice_bed": {
+                    "type": "string",
                     "format": "file-path",
                     "pattern": "^\\S+\\.bed$",
                     "description": "Path to HLA slice BED file.",


### PR DESCRIPTION
This adds a missing type field, as outlined in issue [#93](https://github.com/nf-core/oncoanalyser/issues/93), to an entry in the nextflow_schema.json

Hopefully I have done the change/pull request correctly this time! Thanks!
<!--
# nf-core/oncoanalyser pull request

-->

## PR checklist

- [x ] This comment contains a description of changes (with reason).

