### PR TITLE
Resource requirement tweaks

### DIFF
--- a/modules/local/amber/main.nf
+++ b/modules/local/amber/main.nf
@@ -23,6 +23,8 @@ process AMBER {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.75
+
     def reference_arg = meta.containsKey('normal_id') ? "-reference ${meta.normal_id}" : ''
     def reference_bam_arg = normal_bam ? "-reference_bam ${normal_bam}" : ''
 
@@ -30,7 +32,7 @@ process AMBER {
 
     """
     amber \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         -tumor ${meta.tumor_id} \\
         -tumor_bam ${tumor_bam} \\

--- a/modules/local/amber/main.nf
+++ b/modules/local/amber/main.nf
@@ -30,7 +30,7 @@ process AMBER {
 
     """
     amber \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         ${args} \\
         -tumor ${meta.tumor_id} \\
         -tumor_bam ${tumor_bam} \\

--- a/modules/local/bamtools/main.nf
+++ b/modules/local/bamtools/main.nf
@@ -22,9 +22,11 @@ process BAMTOOLS {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.75
+
     """
     bamtools \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         com.hartwig.hmftools.bamtools.metrics.BamMetrics \\
         ${args} \\
         -sample ${meta.sample_id} \\

--- a/modules/local/bamtools/main.nf
+++ b/modules/local/bamtools/main.nf
@@ -24,7 +24,7 @@ process BAMTOOLS {
 
     """
     bamtools \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         com.hartwig.hmftools.bamtools.metrics.BamMetrics \\
         ${args} \\
         -sample ${meta.sample_id} \\

--- a/modules/local/cobalt/main.nf
+++ b/modules/local/cobalt/main.nf
@@ -23,6 +23,8 @@ process COBALT {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.75
+
     def reference_arg = meta.containsKey('normal_id') ? "-reference ${meta.normal_id}" : ''
     def reference_bam_arg = normal_bam ? "-reference_bam ${normal_bam}" : ''
 
@@ -31,7 +33,7 @@ process COBALT {
 
     """
     cobalt \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         -tumor ${meta.tumor_id} \\
         -tumor_bam ${tumor_bam} \\

--- a/modules/local/cobalt/main.nf
+++ b/modules/local/cobalt/main.nf
@@ -31,7 +31,7 @@ process COBALT {
 
     """
     cobalt \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         ${args} \\
         -tumor ${meta.tumor_id} \\
         -tumor_bam ${tumor_bam} \\

--- a/modules/local/cuppa/main.nf
+++ b/modules/local/cuppa/main.nf
@@ -45,7 +45,7 @@ process CUPPA {
     mkdir -p cuppa/
 
     cuppa \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         ${args} \\
         -sample ${meta.sample_id} \\
         -sample_data_dir sample_data/ \\

--- a/modules/local/cuppa/main.nf
+++ b/modules/local/cuppa/main.nf
@@ -23,6 +23,8 @@ process CUPPA {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.75
+
     """
     # Symlink input files into a single directory
     mkdir -p sample_data/
@@ -45,7 +47,7 @@ process CUPPA {
     mkdir -p cuppa/
 
     cuppa \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         -sample ${meta.sample_id} \\
         -sample_data_dir sample_data/ \\

--- a/modules/local/gripss/germline/main.nf
+++ b/modules/local/gripss/germline/main.nf
@@ -30,7 +30,7 @@ process GRIPSS_GERMLINE {
 
     """
     gripss \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         ${args} \\
         -sample ${meta.normal_id} \\
         -reference ${meta.tumor_id} \\

--- a/modules/local/gripss/germline/main.nf
+++ b/modules/local/gripss/germline/main.nf
@@ -28,9 +28,11 @@ process GRIPSS_GERMLINE {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.75
+
     """
     gripss \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         -sample ${meta.normal_id} \\
         -reference ${meta.tumor_id} \\

--- a/modules/local/gripss/somatic/main.nf
+++ b/modules/local/gripss/somatic/main.nf
@@ -29,13 +29,15 @@ process GRIPSS_SOMATIC {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.75
+
     def reference_arg = meta.containsKey('normal_id') ? "-reference ${meta.normal_id}" : ''
     def target_regions_bed_arg = target_region_bed ? "-target_regions_bed ${target_region_bed}" : ''
     def output_id_arg = meta.containsKey('normal_id') ? '-output_id somatic' : ''
 
     """
     gripss \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         -sample ${meta.tumor_id} \\
         ${reference_arg} \\

--- a/modules/local/gripss/somatic/main.nf
+++ b/modules/local/gripss/somatic/main.nf
@@ -35,7 +35,7 @@ process GRIPSS_SOMATIC {
 
     """
     gripss \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         ${args} \\
         -sample ${meta.tumor_id} \\
         ${reference_arg} \\

--- a/modules/local/isofox/main.nf
+++ b/modules/local/isofox/main.nf
@@ -30,6 +30,8 @@ process ISOFOX {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.75
+
     def functions_arg = functions ? "-functions \'${functions}\'" : ''
 
     def exp_counts_arg = exp_counts ? "-exp_counts_file ${exp_counts}" : ''
@@ -42,7 +44,7 @@ process ISOFOX {
     mkdir -p isofox/
 
     isofox \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         -sample ${meta.sample_id} \\
         -bam_file ${bam} \\

--- a/modules/local/isofox/main.nf
+++ b/modules/local/isofox/main.nf
@@ -42,7 +42,7 @@ process ISOFOX {
     mkdir -p isofox/
 
     isofox \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         ${args} \\
         -sample ${meta.sample_id} \\
         -bam_file ${bam} \\

--- a/modules/local/lilac/main.nf
+++ b/modules/local/lilac/main.nf
@@ -23,6 +23,8 @@ process LILAC {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.75
+
     def sample_name = getSampleName(meta, tumor_dna_bam, normal_dna_bam)
 
     def normal_bam_arg = normal_dna_bam ? "-reference_bam ${normal_dna_bam}" : ''
@@ -33,7 +35,7 @@ process LILAC {
 
     """
     lilac \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         -sample ${sample_name} \\
         ${normal_bam_arg} \\

--- a/modules/local/lilac/main.nf
+++ b/modules/local/lilac/main.nf
@@ -33,7 +33,7 @@ process LILAC {
 
     """
     lilac \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         ${args} \\
         -sample ${sample_name} \\
         ${normal_bam_arg} \\

--- a/modules/local/linx/germline/main.nf
+++ b/modules/local/linx/germline/main.nf
@@ -25,7 +25,7 @@ process LINX_GERMLINE {
 
     """
     linx \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         ${args} \\
         -sample ${meta.sample_id} \\
         -sv_vcf ${sv_vcf} \\

--- a/modules/local/linx/germline/main.nf
+++ b/modules/local/linx/germline/main.nf
@@ -23,9 +23,11 @@ process LINX_GERMLINE {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.75
+
     """
     linx \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         -sample ${meta.sample_id} \\
         -sv_vcf ${sv_vcf} \\

--- a/modules/local/linx/somatic/main.nf
+++ b/modules/local/linx/somatic/main.nf
@@ -24,9 +24,11 @@ process LINX_SOMATIC {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.75
+
     """
     linx \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         -sample ${meta.sample_id} \\
         -sv_vcf ${purple_dir}/${meta.sample_id}.purple.sv.vcf.gz \\

--- a/modules/local/linx/somatic/main.nf
+++ b/modules/local/linx/somatic/main.nf
@@ -26,7 +26,7 @@ process LINX_SOMATIC {
 
     """
     linx \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         ${args} \\
         -sample ${meta.sample_id} \\
         -sv_vcf ${purple_dir}/${meta.sample_id}.purple.sv.vcf.gz \\

--- a/modules/local/linx/visualiser/main.nf
+++ b/modules/local/linx/visualiser/main.nf
@@ -43,7 +43,7 @@ process LINX_VISUALISER {
     # Generate all chromosome and cluster plots by default
 
     linx \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         com.hartwig.hmftools.linx.visualiser.SvVisualiser \\
         ${args} \\
         -sample ${meta.sample_id} \\
@@ -66,7 +66,7 @@ process LINX_VISUALISER {
     # https://github.com/hartwigmedical/hmftools/blob/linx-v1.24.1/linx/src/main/java/com/hartwig/hmftools/linx/visualiser/SampleData.java#L220-L236
 
     linx \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         com.hartwig.hmftools.linx.visualiser.SvVisualiser \\
         ${args2} \\
         -sample ${meta.sample_id} \\

--- a/modules/local/linx/visualiser/main.nf
+++ b/modules/local/linx/visualiser/main.nf
@@ -23,6 +23,8 @@ process LINX_VISUALISER {
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.75
+
     """
     # NOTE(SW): the output plot directories are always required for ORANGE, which is straightfoward to handle with POSIX
     # fs but more involved with FusionFS since it will not write empty directories to S3. A placeholder file can't be
@@ -43,7 +45,7 @@ process LINX_VISUALISER {
     # Generate all chromosome and cluster plots by default
 
     linx \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         com.hartwig.hmftools.linx.visualiser.SvVisualiser \\
         ${args} \\
         -sample ${meta.sample_id} \\
@@ -66,7 +68,7 @@ process LINX_VISUALISER {
     # https://github.com/hartwigmedical/hmftools/blob/linx-v1.24.1/linx/src/main/java/com/hartwig/hmftools/linx/visualiser/SampleData.java#L220-L236
 
     linx \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         com.hartwig.hmftools.linx.visualiser.SvVisualiser \\
         ${args2} \\
         -sample ${meta.sample_id} \\

--- a/modules/local/markdups/main.nf
+++ b/modules/local/markdups/main.nf
@@ -31,7 +31,7 @@ process MARKDUPS {
 
     """
     markdups \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         ${args} \\
         \\
         -samtools \$(which samtools) \\

--- a/modules/local/markdups/main.nf
+++ b/modules/local/markdups/main.nf
@@ -27,11 +27,13 @@ process MARKDUPS {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.95
+
     def umi_flags = has_umis ? '-umi_enabled -umi_duplex -umi_duplex_delim +' : ''
 
     """
     markdups \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         \\
         -samtools \$(which samtools) \\

--- a/modules/local/orange/main.nf
+++ b/modules/local/orange/main.nf
@@ -1,6 +1,6 @@
 process ORANGE {
     tag "${meta.id}"
-    label 'process_single'
+    label 'process_low'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -104,7 +104,7 @@ process ORANGE {
 
     java \\
         --add-opens java.base/java.time=ALL-UNNAMED \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         -jar \${orange_jar} \\
             ${args} \\
             \\

--- a/modules/local/orange/main.nf
+++ b/modules/local/orange/main.nf
@@ -31,6 +31,8 @@ process ORANGE {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.95
+
     def pipeline_version_str = pipeline_version ?: 'not specified'
 
     def virus_dir_arg = virusinterpreter_dir ? "-virus_dir ${virusinterpreter_dir}" : ''
@@ -104,7 +106,7 @@ process ORANGE {
 
     java \\
         --add-opens java.base/java.time=ALL-UNNAMED \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         -jar \${orange_jar} \\
             ${args} \\
             \\

--- a/modules/local/orange/main.nf
+++ b/modules/local/orange/main.nf
@@ -1,6 +1,6 @@
 process ORANGE {
     tag "${meta.id}"
-    label 'process_low'
+    label 'process_single'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/pave/germline/main.nf
+++ b/modules/local/pave/germline/main.nf
@@ -35,6 +35,8 @@ process PAVE_GERMLINE {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.75
+
     def gnomad_args
     if (genome_ver.toString() == '37') {
         gnomad_args = "-gnomad_freq_file ${gnomad_resource}"
@@ -46,7 +48,7 @@ process PAVE_GERMLINE {
 
     """
     pave \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         -sample ${meta.sample_id} \\
         -vcf_file ${sage_vcf} \\

--- a/modules/local/pave/germline/main.nf
+++ b/modules/local/pave/germline/main.nf
@@ -46,7 +46,7 @@ process PAVE_GERMLINE {
 
     """
     pave \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         ${args} \\
         -sample ${meta.sample_id} \\
         -vcf_file ${sage_vcf} \\

--- a/modules/local/pave/somatic/main.nf
+++ b/modules/local/pave/somatic/main.nf
@@ -48,7 +48,7 @@ process PAVE_SOMATIC {
 
     """
     pave \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         ${args} \\
         -sample ${meta.sample_id} \\
         -vcf_file ${sage_vcf} \\

--- a/modules/local/pave/somatic/main.nf
+++ b/modules/local/pave/somatic/main.nf
@@ -31,6 +31,8 @@ process PAVE_SOMATIC {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.75
+
     def pon_filters
     def gnomad_args
     if (genome_ver.toString() == '37') {
@@ -48,7 +50,7 @@ process PAVE_SOMATIC {
 
     """
     pave \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         -sample ${meta.sample_id} \\
         -vcf_file ${sage_vcf} \\

--- a/modules/local/purple/main.nf
+++ b/modules/local/purple/main.nf
@@ -1,6 +1,6 @@
 process PURPLE {
     tag "${meta.id}"
-    label 'process_low'
+    label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -52,7 +52,7 @@ process PURPLE {
 
     """
     purple \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         ${args} \\
         -tumor ${meta.tumor_id} \\
         ${reference_arg} \\

--- a/modules/local/purple/main.nf
+++ b/modules/local/purple/main.nf
@@ -33,6 +33,8 @@ process PURPLE {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.75
+
     def reference_arg = meta.containsKey('normal_id') ? "-reference ${meta.normal_id}" : ''
 
     def sv_tumor_vcf_arg = sv_tumor_vcf ? "-somatic_sv_vcf ${sv_tumor_vcf}" : ''
@@ -52,7 +54,7 @@ process PURPLE {
 
     """
     purple \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         -tumor ${meta.tumor_id} \\
         ${reference_arg} \\

--- a/modules/local/sage/append/main.nf
+++ b/modules/local/sage/append/main.nf
@@ -26,7 +26,7 @@ process SAGE_APPEND {
 
     """
     sage \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         com.hartwig.hmftools.sage.append.SageAppendApplication \\
         ${args} \\
         -input_vcf ${vcf} \\

--- a/modules/local/sage/append/main.nf
+++ b/modules/local/sage/append/main.nf
@@ -1,6 +1,6 @@
 process SAGE_APPEND {
     tag "${meta.id}"
-    label 'process_medium'
+    label 'process_high'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/sage/append/main.nf
+++ b/modules/local/sage/append/main.nf
@@ -1,6 +1,6 @@
 process SAGE_APPEND {
     tag "${meta.id}"
-    label 'process_high'
+    label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/sage/append/main.nf
+++ b/modules/local/sage/append/main.nf
@@ -24,9 +24,11 @@ process SAGE_APPEND {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.75
+
     """
     sage \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         com.hartwig.hmftools.sage.append.SageAppendApplication \\
         ${args} \\
         -input_vcf ${vcf} \\

--- a/modules/local/sage/germline/main.nf
+++ b/modules/local/sage/germline/main.nf
@@ -34,7 +34,7 @@ process SAGE_GERMLINE {
     mkdir germline/
 
     sage \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         ${args} \\
         -tumor ${meta.normal_id} \\
         -tumor_bam ${normal_bam} \\

--- a/modules/local/sage/germline/main.nf
+++ b/modules/local/sage/germline/main.nf
@@ -1,6 +1,6 @@
 process SAGE_GERMLINE {
     tag "${meta.id}"
-    label 'process_medium'
+    label 'process_high'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/sage/germline/main.nf
+++ b/modules/local/sage/germline/main.nf
@@ -30,11 +30,13 @@ process SAGE_GERMLINE {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.95
+
     """
     mkdir germline/
 
     sage \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         -tumor ${meta.normal_id} \\
         -tumor_bam ${normal_bam} \\

--- a/modules/local/sage/somatic/main.nf
+++ b/modules/local/sage/somatic/main.nf
@@ -32,6 +32,8 @@ process SAGE_SOMATIC {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.95
+
     def reference_arg = meta.containsKey('normal_id') ? "-reference ${meta.normal_id}" : ''
     def reference_bam_arg = normal_bam ? "-reference_bam ${normal_bam}" : ''
 
@@ -39,7 +41,7 @@ process SAGE_SOMATIC {
     mkdir -p somatic/
 
     sage \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         ${reference_arg} \\
         ${reference_bam_arg} \\

--- a/modules/local/sage/somatic/main.nf
+++ b/modules/local/sage/somatic/main.nf
@@ -39,7 +39,7 @@ process SAGE_SOMATIC {
     mkdir -p somatic/
 
     sage \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         ${args} \\
         ${reference_arg} \\
         ${reference_bam_arg} \\

--- a/modules/local/sage/somatic/main.nf
+++ b/modules/local/sage/somatic/main.nf
@@ -2,7 +2,7 @@
 
 process SAGE_SOMATIC {
     tag "${meta.id}"
-    label 'process_medium'
+    label 'process_high'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/sigs/main.nf
+++ b/modules/local/sigs/main.nf
@@ -25,7 +25,7 @@ process SIGS {
     mkdir -p sigs/
 
     sigs \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         ${args} \\
         -sample ${meta.sample_id} \\
         -somatic_vcf_file ${smlv_vcf} \\

--- a/modules/local/sigs/main.nf
+++ b/modules/local/sigs/main.nf
@@ -21,11 +21,13 @@ process SIGS {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.75
+
     """
     mkdir -p sigs/
 
     sigs \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         -sample ${meta.sample_id} \\
         -somatic_vcf_file ${smlv_vcf} \\

--- a/modules/local/svprep/assemble/main.nf
+++ b/modules/local/svprep/assemble/main.nf
@@ -26,6 +26,8 @@ process GRIDSS_ASSEMBLE {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.95
+
     def config_arg = gridss_config ? "--configuration ${gridss_config}" : ''
     def output_dirname = 'gridss_assemble'
     def labels_list = labels instanceof List ? labels : [labels]
@@ -74,7 +76,7 @@ process GRIDSS_ASSEMBLE {
     # Run
     gridss_svprep \\
         ${args} \\
-        --jvmheap ${Math.round((task.memory.bytes - otherJvmHeap) * 0.95)} \\
+        --jvmheap ${Math.round((task.memory.bytes - otherJvmHeap) * xmx_mod)} \\
         --otherjvmheap ${otherJvmHeap} \\
         --steps assemble \\
         --labels ${labels_arg} \\

--- a/modules/local/svprep/call/main.nf
+++ b/modules/local/svprep/call/main.nf
@@ -26,6 +26,8 @@ process GRIDSS_CALL {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.75
+
     def config_arg = gridss_config ? "--configuration ${gridss_config}" : ''
     def output_dirname = 'gridss_call'
     def labels_list = labels instanceof List ? labels : [labels]
@@ -72,7 +74,7 @@ process GRIDSS_CALL {
     # Run
     gridss_svprep \\
         ${args} \\
-        --jvmheap ${Math.round((task.memory.bytes - otherJvmHeap) * 0.95)} \\
+        --jvmheap ${Math.round((task.memory.bytes - otherJvmHeap) * xmx_mod)} \\
         --otherjvmheap ${otherJvmHeap} \\
         --steps call \\
         --labels ${labels_arg} \\

--- a/modules/local/svprep/depth_annotator/main.nf
+++ b/modules/local/svprep/depth_annotator/main.nf
@@ -23,6 +23,8 @@ process SVPREP_DEPTH_ANNOTATOR {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.95
+
     def labels_list = labels instanceof List ? labels : [labels]
     def labels_arg = labels_list.join(',')
     // NOTE(SW): Nextflow implicitly casts List<TaskPath> to an atomic TaskPath, hence the required check below
@@ -31,7 +33,7 @@ process SVPREP_DEPTH_ANNOTATOR {
 
     """
     svprep \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         com.hartwig.hmftools.svprep.depth.DepthAnnotator \\
         ${args} \\
         -input_vcf ${vcf} \\

--- a/modules/local/svprep/depth_annotator/main.nf
+++ b/modules/local/svprep/depth_annotator/main.nf
@@ -31,7 +31,7 @@ process SVPREP_DEPTH_ANNOTATOR {
 
     """
     svprep \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         com.hartwig.hmftools.svprep.depth.DepthAnnotator \\
         ${args} \\
         -input_vcf ${vcf} \\

--- a/modules/local/svprep/preprocess/main.nf
+++ b/modules/local/svprep/preprocess/main.nf
@@ -25,6 +25,8 @@ process GRIDSS_PREPROCESS {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.95
+
     def config_arg = gridss_config ? "--configuration ${gridss_config}" : ''
 
     """
@@ -33,7 +35,7 @@ process GRIDSS_PREPROCESS {
 
     gridss_svprep \\
         ${args} \\
-        --jvmheap ${Math.round(task.memory.bytes * 0.95)} \\
+        --jvmheap ${Math.round(task.memory.bytes * xmx_mod)} \\
         --steps preprocess \\
         --reference ${genome_fasta} \\
         --workingdir gridss_preprocess/ \\

--- a/modules/local/svprep/svprep/main.nf
+++ b/modules/local/svprep/svprep/main.nf
@@ -27,12 +27,14 @@ process SVPREP {
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.95
+
     def write_types_arg = write_types ? "-write_types \'${write_types}\'" : ''
     def existing_juction_file_arg = junctions ? "-existing_junction_file ${junctions}" : ''
 
     """
     svprep \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         -sample ${meta.sample_id} \\
         -bam_file ${bam} \\

--- a/modules/local/virusbreakend/main.nf
+++ b/modules/local/virusbreakend/main.nf
@@ -27,13 +27,15 @@ process VIRUSBREAKEND {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.95
+
     """
     # Symlink indices next to assembly FASTA
     ln -s \$(find -L ${genome_gridss_index} -regex '.*\\.\\(amb\\|ann\\|pac\\|gridsscache\\|sa\\|bwt\\|img\\|alt\\)') ./
 
     virusbreakend \\
         ${args} \\
-        --gridssargs "--jvmheap ${Math.round(task.memory.bytes * 0.95)}" \\
+        --gridssargs "--jvmheap ${Math.round(task.memory.bytes * xmx_mod)}" \\
         --threads ${task.cpus} \\
         --db ${virusbreakenddb.toString().replaceAll("/\$", "")}/ \\
         --output ${meta.sample_id}.virusbreakend.vcf \\

--- a/modules/local/virusinterpreter/main.nf
+++ b/modules/local/virusinterpreter/main.nf
@@ -26,7 +26,7 @@ process VIRUSINTERPRETER {
     mkdir -p virusinterpreter/
 
     virusinterpreter \\
-        -Xmx${Math.round(task.memory.bytes * 0.95)} \\
+        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
         ${args} \\
         -sample ${meta.sample_id} \\
         -purple_dir ${purple_dir} \\

--- a/modules/local/virusinterpreter/main.nf
+++ b/modules/local/virusinterpreter/main.nf
@@ -22,11 +22,13 @@ process VIRUSINTERPRETER {
     script:
     def args = task.ext.args ?: ''
 
+    def xmx_mod = task.ext.xmx_mod ?: 0.95
+
     """
     mkdir -p virusinterpreter/
 
     virusinterpreter \\
-        -Xmx${Math.round(task.memory.bytes * 0.75)} \\
+        -Xmx${Math.round(task.memory.bytes * xmx_mod)} \\
         ${args} \\
         -sample ${meta.sample_id} \\
         -purple_dir ${purple_dir} \\


### PR DESCRIPTION
Solves #106 . 

When testing out oncoanalyser against some more difficult samples I ran into quite some erratic behaviour of stages running out of memory. 
In general this was caused by the java process allocating 95% of available memory, followed by the java process invoking an external (usually R) script. This would cause the container to go over the memory limits set in the `base.config`, and the container would be killed by the supervisor (in my case k8s). 
Even without an external application (outside of java) being invoked this can happen. The `Xmx` parameter only sets the size of the heap. The GC operates outside of this. So if the heap fills up, the GC kicks in, filling up the remaining memory, and causing the whole container to go OOM.
Also, some stages, like purple and sage are set to a resource class that is too low for the amount of work they need to do, especially for more difficult samples.

Therefore we don't set the size of the heap higher than 75% of the container memory limits when running hmftools (see [pipeline5](https://github.com/hartwigmedical/pipeline5/blob/15f1d356bcb45e62f7e76efc37cd64dded344343/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java#L9), second is heap memory and third arg is total memory). After changing this the stability of the pipeline greatly improved. I went from sage+purple pretty much always going OOM to the pipeline completing successfully even for difficult samples. 

I also bumped the process requirements for purple, sage, and orange. This brings it more in line with the resource requirements set in [pipeline5](https://github.com/hartwigmedical/pipeline5/blob/15f1d356bcb45e62f7e76efc37cd64dded344343/cluster/src/main/java/com/hartwig/pipeline/tools/HmfTool.java#L9). These extra resources are necessary to finish more difficult samples in a reasonable of time and without going OOM.

