### PR TITLE
Enhancement/cancer type parameter reporting in ORANGE 

### DIFF
--- a/modules/local/orange/main.nf
+++ b/modules/local/orange/main.nf
@@ -53,6 +53,8 @@ process ORANGE {
     def isofox_gene_distribution_arg = isofox_gene_distribution ? "-isofox_gene_distribution ${isofox_gene_distribution}" : ''
     def isofox_alt_sj_arg = isofox_alt_sj ? "-isofox_alt_sj_cohort ${isofox_alt_sj}" : ''
 
+    def doid_arg = meta.cancer_type ?: "162"
+
     """
     echo "${pipeline_version_str}" > pipeline_version.txt
 
@@ -115,7 +117,7 @@ process ORANGE {
             -pipeline_version_file pipeline_version.txt \\
             \\
             -tumor_sample_id ${meta.tumor_id} \\
-            -primary_tumor_doids 162 \\
+            -primary_tumor_doids ${doid_arg} \\
             -tumor_sample_wgs_metrics_file ${bam_metrics_somatic} \\
             -tumor_sample_flagstat_file ${flagstat_somatic} \\
             -sage_dir ${sage_somatic_dir} \\

--- a/subworkflows/local/orange_reporting/main.nf
+++ b/subworkflows/local/orange_reporting/main.nf
@@ -179,6 +179,7 @@ workflow ORANGE_REPORTING {
                 key: meta.group_id,
                 id: meta.group_id,
                 tumor_id: Utils.getTumorDnaSampleName(meta),
+                cancer_type: meta[Constants.InfoField.CANCER_TYPE],
             ]
 
             def inputs_selected = inputs.clone()


### PR DESCRIPTION
# nf-core/oncoanalyser pull request
## PR checklist

- [X] This comment contains a description of changes (with reason).
Utils.groovy
- New getCancerType method to provide user-provided doid data in the metamap for the ORANGE process to use
- Added CancerType check during development 

Modules > Local > Orange>main.nf
- Included cancer_type as a value input in ORANGE process 
- Provided doid_arg in ORANGE command 

Subworkflows > orange_reporting > main.nf
- Added the cancer_type information in the orange process metamap (as well as overarching metamap)

nf-core pipelines linting 
- nextflow.config > Adjusted profile loading syntax (caused failed tests)
- .nf-core.yml > nextflow config (params compute resources maximums) scope was causing issues (params.max_cpus, params.max_memory, params.max_time), skipped specifically
& files_unchanged +  actions_awsfulltest set to false 
& files_exist, included lib folder (only Utils, WorkflowMain, WorkflowOncoanalyser

*Additionally: ran the ```nf-core pipelines lint --dir . --fix files_unchanged``` and caused some cascading changes to meet nf-core standards and pass linting tests

- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`)
