### PR TITLE
Samtools for ARM64

### DIFF
--- a/modules/local/bwa-mem2/mem/environment.yml
+++ b/modules/local/bwa-mem2/mem/environment.yml
@@ -5,5 +5,5 @@ channels:
   - defaults
 dependencies:
   - bioconda::bwa-mem2=2.2.1
-  - bioconda::samtools=1.19.2
+  - bioconda::samtools=1.21
   - bioconda::sambamba=1.0.1

--- a/modules/local/custom/lilac_slice/main.nf
+++ b/modules/local/custom/lilac_slice/main.nf
@@ -2,7 +2,7 @@ process CUSTOM_SLICE {
     tag "${meta.id}"
     label 'process_single'
 
-    conda "samtools=1.19.2"
+    conda "samtools=1.21"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/samtools:1.19.2--h50ea8bc_0' :
         'biocontainers/samtools:1.19.2--h50ea8bc_0' }"

--- a/modules/nf-core/samtools/dict/main.nf
+++ b/modules/nf-core/samtools/dict/main.nf
@@ -2,7 +2,7 @@ process SAMTOOLS_DICT {
     tag "$fasta"
     label 'process_single'
 
-    conda (params.enable_conda ? "bioconda::samtools=1.16.1" : null)
+    conda (params.enable_conda ? "bioconda::samtools=1.21" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/samtools:1.16.1--h6899075_1' :
         'biocontainers/samtools:1.16.1--h6899075_1' }"


### PR DESCRIPTION
In line with our discussions with @scwatts, this PR bumps samtools to [bioconda's 1.21](https://anaconda.org/bioconda/samtools) to address build failure (https://wave.seqera.io/view/builds/bd-ea05fc7cfdaac5fc_3) due to missing `linux-aarch64` package.

This is for testing purposes only, whether to release under `1.0.1` and/or `2.0.0` remains under @scwatts discretion ;)

/cc @mmalenic @ohofmann
