### PR TITLE
Restore CUPPA RNA only mode

### DIFF
--- a/modules/local/cuppa/environment.yml
+++ b/modules/local/cuppa/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::hmftools-cuppa=2.3.1
+  - bioconda::hmftools-cuppa=2.3.2

--- a/modules/local/cuppa/main.nf
+++ b/modules/local/cuppa/main.nf
@@ -4,8 +4,8 @@ process CUPPA {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/hmftools-cuppa:2.3.1--py311r42hdfd78af_0' :
-        'biocontainers/hmftools-cuppa:2.3.1--py311r42hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/hmftools-cuppa:2.3.2--py311r42hdfd78af_0' :
+        'biocontainers/hmftools-cuppa:2.3.2--py311r42hdfd78af_0' }"
 
     input:
     tuple val(meta), path(isofox_dir), path(purple_dir), path(linx_dir), path(virusinterpreter_dir)


### PR DESCRIPTION
- CUPPA RNA only mode is no longer available in the 2.3.1 release
- support was also removed from the CUPPA NF process in the WiGiTS 2.0 (fka WiGiTS 6.0) PR 
- this PR restores support for RNA only mode in the NF process, updates to the CUPPA 2.3.2 release