### PR TITLE
Pin VIRUSBreakend dependency RepeatMasker to 4.1.5

### DIFF
--- a/modules/local/virusbreakend/environment.yml
+++ b/modules/local/virusbreakend/environment.yml
@@ -5,4 +5,5 @@ channels:
   - defaults
 dependencies:
   - bioconda::gridss=2.13.2=h50ea8bc_3
+  - repeatmasker=4.1.5
   - grep


### PR DESCRIPTION
- when running oncoanalyser with `-profile conda` require the VIRUSBreakend environment to install RepeatMasker 4.1.5
- newer versions of the RepeatMasker package expects a user-provided database
- additionally provides consistency with the Docker / Singularity image used