### PR TITLE
Fix BAM / CRAM index discovery

### DIFF
--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -144,11 +144,9 @@ class Utils {
                         def index_enum
                         def index_str
 
-                        def fp = meta[sample_key][key].toString()
-
                         if (key === Constants.FileType.BAM) {
                             index_enum = Constants.FileType.BAI
-                            index_str = (fp.endsWith('cram')) ? 'crai' : 'bai'
+                            index_str = (meta[sample_key][key].toString().endsWith('cram')) ? 'crai' : 'bai'
                         } else if (key === Constants.FileType.BAM_REDUX) {
                             index_enum = Constants.FileType.BAI
                             index_str = 'bai'
@@ -166,6 +164,7 @@ class Utils {
                             return
                         }
 
+                        def fp = meta[sample_key][key].toUriString()
                         def index_fp = nextflow.Nextflow.file("${fp}.${index_str}")
 
                         if (!index_fp.exists() && !stub_run) {


### PR DESCRIPTION
- casting a NF filepath to a string with `toString()` causes loss of the URI scheme
- this causes filepath construction from such a string for cloud platform paths impossible
- the changes here preserve the simple CRAM / BAM index check while retaining cloud platform compatibility 