### PR TITLE
Fix utilisation of user-provided BamTools directory

### DIFF
--- a/lib/Constants.groovy
+++ b/lib/Constants.groovy
@@ -63,7 +63,6 @@ class Constants {
         REDUX_MS_TSV,
         // Process
         AMBER_DIR,
-        BAMTOOLS,
         BAMTOOLS_DIR,
         COBALT_DIR,
         ESVEE_VCF,
@@ -251,18 +250,13 @@ class Constants {
             SequenceType.DNA,
         ],
 
-        BAMTOOLS_DIR: [
+        BAMTOOLS_DIR_TUMOR: [
             FileType.BAMTOOLS_DIR,
-            [SampleType.TUMOR, SampleType.TUMOR_NORMAL],
-            SequenceType.DNA,
-        ],
-        BAMTOOLS_TUMOR: [
-            FileType.BAMTOOLS,
             SampleType.TUMOR,
             SequenceType.DNA,
         ],
-        BAMTOOLS_NORMAL: [
-            FileType.BAMTOOLS,
+        BAMTOOLS_DIR_NORMAL: [
+            FileType.BAMTOOLS_DIR,
             SampleType.NORMAL,
             SequenceType.DNA,
         ],

--- a/subworkflows/local/bamtools_metrics/main.nf
+++ b/subworkflows/local/bamtools_metrics/main.nf
@@ -35,7 +35,7 @@ workflow BAMTOOLS_METRICS {
             ]
         }
         .branch { meta, bam, bai ->
-            def has_existing = Utils.hasExistingInput(meta, Constants.INPUT.BAMTOOLS_TUMOR)
+            def has_existing = Utils.hasExistingInput(meta, Constants.INPUT.BAMTOOLS_DIR_TUMOR)
             runnable: bam && !has_existing
             skip: true
                 return meta
@@ -52,7 +52,7 @@ workflow BAMTOOLS_METRICS {
             ]
         }
         .branch { meta, bam, bai ->
-            def has_existing = Utils.hasExistingInput(meta, Constants.INPUT.BAMTOOLS_NORMAL)
+            def has_existing = Utils.hasExistingInput(meta, Constants.INPUT.BAMTOOLS_DIR_NORMAL)
             runnable: bam && !has_existing
             skip: true
                 return meta

--- a/subworkflows/local/orange_reporting/main.nf
+++ b/subworkflows/local/orange_reporting/main.nf
@@ -99,8 +99,8 @@ workflow ORANGE_REPORTING {
             // NOTE(SW): avoiding further complexity with loops etc
 
             def inputs_selected = [
-                Utils.selectCurrentOrExisting(inputs[0], meta, Constants.INPUT.BAMTOOLS_TUMOR),
-                Utils.selectCurrentOrExisting(inputs[1], meta, Constants.INPUT.BAMTOOLS_NORMAL),
+                Utils.selectCurrentOrExisting(inputs[0], meta, Constants.INPUT.BAMTOOLS_DIR_TUMOR),
+                Utils.selectCurrentOrExisting(inputs[1], meta, Constants.INPUT.BAMTOOLS_DIR_NORMAL),
                 Utils.selectCurrentOrExisting(inputs[2], meta, Constants.INPUT.SAGE_DIR_TUMOR),
                 Utils.selectCurrentOrExisting(inputs[3], meta, Constants.INPUT.SAGE_DIR_NORMAL),
                 Utils.selectCurrentOrExisting(inputs[4], meta, Constants.INPUT.SAGE_APPEND_VCF_TUMOR),

--- a/subworkflows/local/virusbreakend_calling/main.nf
+++ b/subworkflows/local/virusbreakend_calling/main.nf
@@ -97,7 +97,7 @@ workflow VIRUSBREAKEND_CALLING {
             def inputs = [
                 virus_tsv,
                 Utils.selectCurrentOrExisting(purple_dir, meta, Constants.INPUT.PURPLE_DIR),
-                Utils.selectCurrentOrExisting(somatic_metrics, meta, Constants.INPUT.BAMTOOLS_DIR),
+                Utils.selectCurrentOrExisting(somatic_metrics, meta, Constants.INPUT.BAMTOOLS_DIR_TUMOR),
             ]
 
             return [meta, *inputs]


### PR DESCRIPTION
- removes `BAMTOOLS` input filetype (input processing / parsing)
- replaces internal BamTools representation (input look-up)
  - `BAMTOOLS_TUMOR` → `BAMTOOLS_DIR_TUMOR`
  - `BAMTOOLS_NORMAL` → `BAMTOOLS_DIR_NORMAL`