### PR TITLE
Enable loading custom pipeline config

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -199,8 +199,7 @@ profiles {
 includeConfig !System.getenv('NXF_OFFLINE') && params.custom_config_base ? "${params.custom_config_base}/nfcore_custom.config" : "/dev/null"
 
 // Load nf-core/oncoanalyser custom profiles from different institutions.
-// TODO nf-core: Optionally, you can add a pipeline-specific nf-core config at https://github.com/nf-core/configs
-// includeConfig !System.getenv('NXF_OFFLINE') && params.custom_config_base ? "${params.custom_config_base}/pipeline/oncoanalyser.config" : "/dev/null"
+includeConfig !System.getenv('NXF_OFFLINE') && params.custom_config_base ? "${params.custom_config_base}/pipeline/oncoanalyser.config" : "/dev/null"
 
 // Set default registry for Apptainer, Docker, Podman, Charliecloud and Singularity independent of -profile
 // Will not be used unless Apptainer / Docker / Podman / Charliecloud / Singularity are enabled


### PR DESCRIPTION
- running `nf-core pipelines lint --release` encounters the below lint failure
- uncommenting the corresponding `includeConfig` statement resolves

```text
included_configs: Pipeline config does not include custom configs. Please uncomment the includeConfig line. 
```