### PR TITLE
Fix the download pipeline CI/CD

### DIFF
--- a/.github/workflows/download_pipeline.yml
+++ b/.github/workflows/download_pipeline.yml
@@ -83,20 +83,12 @@ jobs:
           echo "Initial container image count: $image_count"
           echo "IMAGE_COUNT_INITIAL=$image_count" >> ${GITHUB_ENV}
 
-      - name: Run the downloaded pipeline (stub)
+      - name: Run the downloaded pipeline
         id: stub_run_pipeline
-        continue-on-error: true
         env:
           NXF_SINGULARITY_CACHEDIR: ./singularity_container_images
           NXF_SINGULARITY_HOME_MOUNT: true
         run: nextflow run ./${{ env.REPOTITLE_LOWERCASE }}/$( sed 's/\W/_/g' <<< ${{ env.REPO_BRANCH }}) -stub -profile test_stub,singularity --outdir ./results
-      - name: Run the downloaded pipeline (stub run not supported)
-        id: run_pipeline
-        if: ${{ job.steps.stub_run_pipeline.status == failure() }}
-        env:
-          NXF_SINGULARITY_CACHEDIR: ./singularity_container_images
-          NXF_SINGULARITY_HOME_MOUNT: true
-        run: nextflow run ./${{ env.REPOTITLE_LOWERCASE }}/$( sed 's/\W/_/g' <<< ${{ env.REPO_BRANCH }}) -profile test_stub,singularity --outdir ./results
 
       - name: Count the downloaded number of container images
         id: count_afterwards


### PR DESCRIPTION
- the standard pipeline download job using stub mode works
- however the fallback job that uses non-stub mode also runs then fails
- the unnecessary non-stub mode job is removed to prevent it from running