### PR TITLE
Fix integer overflow of fastp --split_by_lines value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [dev]
 
+- [190](https://github.com/nf-core/oncoanalyser/pull/190) - Fix integer overflow of fastp `--split_by_lines` value
 - [200](https://github.com/nf-core/oncoanalyser/pull/200) - Downgrade nf-schema to 2.2.0
 - [199](https://github.com/nf-core/oncoanalyser/pull/199) - Post-release bump
 

--- a/modules/local/fastp/main.nf
+++ b/modules/local/fastp/main.nf
@@ -24,7 +24,7 @@ process FASTP {
     script:
     def args = task.ext.args ?: ''
 
-    def split_by_lines_arg = max_fastq_records > 0 ? "--split_by_lines ${4 * max_fastq_records}" : ''
+    def split_by_lines_arg = max_fastq_records > 0 ? "--split_by_lines ${4 * max_fastq_records.toLong()}" : ''
 
     def umi_args_list = []
     if (umi_location) umi_args_list.add("--umi_loc ${umi_location}")


### PR DESCRIPTION
- the fastp split_by_lines argument value is calculated from max_fastq_records
- max_fastq_records values greater or equal to 536,870,912 (2 ^ 32 / 2 / 4) cause an integer overflow
- this is fixed by casting max_fastq_records to a Long type before calculating the value for split_by_lines