### PR TITLE
Fix output prepared reference data directory names

### DIFF
--- a/conf/hmf_genomes.config
+++ b/conf/hmf_genomes.config
@@ -14,9 +14,9 @@ params {
             fai           = "${params.hmf_genomes_base}/GRCh37_hmf/24.0/samtools_index/1.16/Homo_sapiens.GRCh37.GATK.illumina.fasta.fai"
             dict          = "${params.hmf_genomes_base}/GRCh37_hmf/24.0/samtools_index/1.16/Homo_sapiens.GRCh37.GATK.illumina.fasta.dict"
             img           = "${params.hmf_genomes_base}/GRCh37_hmf/24.0/bwa_index_image/0.7.17-r1188/Homo_sapiens.GRCh37.GATK.illumina.fasta.img"
-            gridss_index  = "${params.hmf_genomes_base}/GRCh37_hmf/24.1/gridss_index/2.13.2.tar.gz"
-            bwamem2_index = "${params.hmf_genomes_base}/GRCh37_hmf/24.1/bwa-mem2_index/2.2.1.tar.gz"
-            star_index    = "${params.hmf_genomes_base}/GRCh37_hmf/24.0/star_index/gencode_19/2.7.3a.tar.gz"
+            gridss_index  = "${params.hmf_genomes_base}/GRCh37_hmf/25.1/gridss_index-2.13.2.tar.gz"
+            bwamem2_index = "${params.hmf_genomes_base}/GRCh37_hmf/25.1/bwa-mem2_index-2.2.1.tar.gz"
+            star_index    = "${params.hmf_genomes_base}/GRCh37_hmf/25.1/star_index-gencode_19-2.7.3a.tar.gz"
         }
         'GRCh38_hmf' {
             fasta         = "${params.hmf_genomes_base}/GRCh38_hmf/25.1/GRCh38_masked_exclusions_alts_hlas.fasta"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -545,9 +545,9 @@ _GRCh37 genome (Hartwig): `GRCh37_hmf`_
 | FASTA index          | [Homo_sapiens.GRCh37.GATK.illumina.fasta.fai](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/samtools_index/1.16/Homo_sapiens.GRCh37.GATK.illumina.fasta.fai)          |
 | FASTA seq dictionary | [Homo_sapiens.GRCh37.GATK.illumina.fasta.dict](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/samtools_index/1.16/Homo_sapiens.GRCh37.GATK.illumina.fasta.dict)        |
 | BWA-MEM2 index image | [Homo_sapiens.GRCh37.GATK.illumina.fasta.img](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/bwa_index_image/0.7.17-r1188/Homo_sapiens.GRCh37.GATK.illumina.fasta.img) |
-| BWA-MEM2 index       | [bwa-mem2_index/2.2.1.tar.gz](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.1/bwa-mem2_index/2.2.1.tar.gz)                                                              |
-| GRIDSS index         | [gridss_index/2.13.2.tar.gz](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.1/gridss_index/2.13.2.tar.gz)                                                                |
-| STAR index           | [star_index/gencode_19/2.7.3a.tar.gz](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/24.0/star_index/gencode_19/2.7.3a.tar.gz)                                              |
+| BWA-MEM2 index       | [bwa-mem2_index-2.2.1.tar.gz](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/25.1/bwa-mem2_index-2.2.1.tar.gz)                                                              |
+| GRIDSS index         | [gridss_index-2.13.2.tar.gz](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/25.1/gridss_index-2.13.2.tar.gz)                                                                |
+| STAR index           | [star_index-gencode_19-2.7.3a.tar.gz](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/genomes/GRCh37_hmf/25.1/star_index-gencode_19-2.7.3a.tar.gz)                                              |
 | WiGiTS data          | [hmf_pipeline_resources.37_v2.0.0--3.tar.gz](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/hmf_reference_data/hmftools/hmf_pipeline_resources.37_v2.0.0--3.tar.gz)                            |
 | TSO500 panel data    | [hmf_panel_resources.tso500.37_v2.0.0--3.tar.gz](https://pub-cf6ba01919994c3cbd354659947f74d8.r2.dev/hmf_reference_data/panels/hmf_panel_resources.tso500.37_v2.0.0--3.tar.gz)                      |
 

--- a/modules/local/gridss/index/main.nf
+++ b/modules/local/gridss/index/main.nf
@@ -26,7 +26,7 @@ process GRIDSS_INDEX {
 
     """
     # Symlink BWA indices next to assembly FASTA
-    ln -s \$(find -L ${genome_bwa_index} -type f) ./
+    ln -s \$(find -L ${genome_bwa_index}/${genome_fasta.name}.*) ./
 
     # Create indexes
     PrepareReference \\

--- a/subworkflows/local/prepare_reference/main.nf
+++ b/subworkflows/local/prepare_reference/main.nf
@@ -76,7 +76,7 @@ workflow PREPARE_REFERENCE {
         } else if (params.ref_data_genome_bwamem2_index.endsWith('.tar.gz')) {
 
             ch_genome_bwamem2_index_inputs = Channel.fromPath(params.ref_data_genome_bwamem2_index)
-                .map { [[id: "bwa-mem2_index_${it.name.replaceAll('\\.tar\\.gz$', '')}"], it] }
+                .map { [[id: "${it.name.replaceAll('\\.tar\\.gz$', '')}"], it] }
 
             DECOMP_BWAMEM2_INDEX(ch_genome_bwamem2_index_inputs)
             ch_genome_bwamem2_index = DECOMP_BWAMEM2_INDEX.out.extracted_dir
@@ -113,7 +113,7 @@ workflow PREPARE_REFERENCE {
         } else if (params.ref_data_genome_gridss_index.endsWith('.tar.gz')) {
 
             ch_genome_gridss_index_inputs = Channel.fromPath(params.ref_data_genome_gridss_index)
-                .map { [[id: "gridss_index_${it.name.replaceAll('\\.tar\\.gz$', '')}"], it] }
+                .map { [[id: "${it.name.replaceAll('\\.tar\\.gz$', '')}"], it] }
 
             DECOMP_GRIDSS_INDEX(ch_genome_gridss_index_inputs)
             ch_genome_gridss_index = DECOMP_GRIDSS_INDEX.out.extracted_dir
@@ -142,7 +142,7 @@ workflow PREPARE_REFERENCE {
         } else if (params.ref_data_genome_star_index.endsWith('.tar.gz')) {
 
             ch_genome_star_index_inputs = Channel.fromPath(params.ref_data_genome_star_index)
-                .map { [[id: "star_index_${it.name.replaceAll('\\.tar\\.gz$', '')}"], it] }
+                .map { [[id: "${it.name.replaceAll('\\.tar\\.gz$', '')}"], it] }
 
             DECOMP_STAR_INDEX(ch_genome_star_index_inputs)
             ch_genome_star_index = DECOMP_STAR_INDEX.out.extracted_dir
@@ -162,7 +162,7 @@ workflow PREPARE_REFERENCE {
     if (params.ref_data_hmf_data_path.endsWith('tar.gz')) {
 
         ch_hmf_data_inputs = Channel.fromPath(params.ref_data_hmf_data_path)
-            .map { [[id: "hmf_data_${it.name.replaceAll('\\.tar\\.gz$', '')}"], it] }
+            .map { [[id: "${it.name.replaceAll('\\.tar\\.gz$', '')}"], it] }
 
         DECOMP_HMF_DATA(ch_hmf_data_inputs)
 
@@ -192,7 +192,7 @@ workflow PREPARE_REFERENCE {
         if (params.ref_data_panel_data_path.endsWith('tar.gz')) {
 
             ch_panel_data_inputs = Channel.fromPath(params.ref_data_panel_data_path)
-                .map { [[id: "panel_data_${it.name.replaceAll('\\.tar\\.gz$', '')}"], it] }
+                .map { [[id: "${it.name.replaceAll('\\.tar\\.gz$', '')}"], it] }
 
             DECOMP_PANEL_DATA(ch_panel_data_inputs)
 


### PR DESCRIPTION
- changes in the naming scheme of the new Hartwig GRCh38 reference causes repetition in output directory names
  - see: https://github.com/nf-core/oncoanalyser/issues/193#issuecomment-2826422239
- output naming is made consistent as in the 1.0.0 release by:
  - adjusting the Nextflow code, specifically the `meta.id` for directory / archive decompression tasks
  - aligning the Hartwig GRCh37 reference structure with the new Hartwig GRCh38 reference
  - no changes to the reference files themselves has been made
- additionally, discovery of the BWA index discovery is improved for certain execution / compute contexts

<br />

<details><summary>GRCh38_hmf reference output structure (click to expand)</summary>

```text
$ nextflow run oncoanalyser/main.nf \
  -profile docker \
  -ansi-log false \
  --monochrome_logs \
  --mode wgts \
  --genome GRCh38_hmf \
  \
  --prepare_reference_only \
  \
  --input samplesheet.csv \
  --outdir output.grch38_hmf/

$ tree -L 2 output.grch38_hmf/reference_data/*/*/
output.grch38_hmf/reference_data/2.1.0dev/20250603_232419/
├── GRCh38_masked_exclusions_alts_hlas.fasta
├── GRCh38_masked_exclusions_alts_hlas.fasta.dict
├── GRCh38_masked_exclusions_alts_hlas.fasta.fai
├── GRCh38_masked_exclusions_alts_hlas.fasta.img
├── bwa-mem2_index-2.2.1
│   ├── GRCh38_masked_exclusions_alts_hlas.fasta.0123
│   ├── GRCh38_masked_exclusions_alts_hlas.fasta.amb
│   ├── GRCh38_masked_exclusions_alts_hlas.fasta.ann
│   ├── GRCh38_masked_exclusions_alts_hlas.fasta.bwt.2bit.64
│   └── GRCh38_masked_exclusions_alts_hlas.fasta.pac
├── gridss_index-2.13.2
│   ├── GRCh38_masked_exclusions_alts_hlas.fasta.amb
│   ├── GRCh38_masked_exclusions_alts_hlas.fasta.ann
│   ├── GRCh38_masked_exclusions_alts_hlas.fasta.bwt
│   ├── GRCh38_masked_exclusions_alts_hlas.fasta.gridsscache
│   ├── GRCh38_masked_exclusions_alts_hlas.fasta.img
│   ├── GRCh38_masked_exclusions_alts_hlas.fasta.pac
│   └── GRCh38_masked_exclusions_alts_hlas.fasta.sa
├── hmf_pipeline_resources.38_v2.0.0--3
│   ├── common
│   ├── dna
│   ├── misc
│   └── rna
└── star_index-gencode_38-2.7.3a
    ├── Genome
    ├── SA
    ├── SAindex
    ├── chrLength.txt
    ├── chrName.txt
    ├── chrNameLength.txt
    ├── chrStart.txt
    ├── exonGeTrInfo.tab
    ├── exonInfo.tab
    ├── geneInfo.tab
    ├── genomeParameters.txt
    ├── sjdbInfo.txt
    ├── sjdbList.fromGTF.out.tab
    ├── sjdbList.out.tab
    └── transcriptInfo.tab
```

</details>

<details><summary>GRCh37_hmf reference output structure (click to expand)</summary>

```text
$ nextflow run oncoanalyser/main.nf \
  -profile docker \
  -ansi-log false \
  --monochrome_logs \
  --mode wgts \
  --genome GRCh37_hmf \
  \
  --prepare_reference_only \
  \
  --input samplesheet.csv \
  --outdir output.grch37_hmf/

$ tree -L 2 output.grch37_hmf/reference_data/*/*
output.grch37_hmf/reference_data/2.1.0dev/20250603_232438
├── Homo_sapiens.GRCh37.GATK.illumina.fasta
├── Homo_sapiens.GRCh37.GATK.illumina.fasta.dict
├── Homo_sapiens.GRCh37.GATK.illumina.fasta.fai
├── Homo_sapiens.GRCh37.GATK.illumina.fasta.img
├── bwa-mem2_index-2.2.1
│   ├── Homo_sapiens.GRCh37.GATK.illumina.fasta.0123
│   ├── Homo_sapiens.GRCh37.GATK.illumina.fasta.amb
│   ├── Homo_sapiens.GRCh37.GATK.illumina.fasta.ann
│   ├── Homo_sapiens.GRCh37.GATK.illumina.fasta.bwt.2bit.64
│   └── Homo_sapiens.GRCh37.GATK.illumina.fasta.pac
├── gridss_index-2.13.2
│   ├── Homo_sapiens.GRCh37.GATK.illumina.fasta.amb
│   ├── Homo_sapiens.GRCh37.GATK.illumina.fasta.ann
│   ├── Homo_sapiens.GRCh37.GATK.illumina.fasta.bwt
│   ├── Homo_sapiens.GRCh37.GATK.illumina.fasta.gridsscache
│   ├── Homo_sapiens.GRCh37.GATK.illumina.fasta.img
│   ├── Homo_sapiens.GRCh37.GATK.illumina.fasta.pac
│   └── Homo_sapiens.GRCh37.GATK.illumina.fasta.sa
├── hmf_pipeline_resources.37_v2.0.0--3
│   ├── common
│   ├── dna
│   ├── misc
│   └── rna
└── star_index-gencode_19-2.7.3a
    ├── Genome
    ├── SA
    ├── SAindex
    ├── chrLength.txt
    ├── chrName.txt
    ├── chrNameLength.txt
    ├── chrStart.txt
    ├── exonGeTrInfo.tab
    ├── exonInfo.tab
    ├── geneInfo.tab
    ├── genomeParameters.txt
    ├── sjdbInfo.txt
    ├── sjdbList.fromGTF.out.tab
    ├── sjdbList.out.tab
    └── transcriptInfo.tab
```

</details>