### PR TITLE
Prevent ORANGE running with incompatible CUPPA inputs

### DIFF
--- a/subworkflows/local/orange_reporting/main.nf
+++ b/subworkflows/local/orange_reporting/main.nf
@@ -68,6 +68,7 @@ workflow ORANGE_REPORTING {
     ]
 
     rna_sage_germline_append_index = 7  // sage_germline_append
+    cuppa_dir_index = 14                // cuppa_dir
 
     // Select input sources
     // channel: [ meta, tbt_metrics_dir, nbt_metrics_dir, tsage_dir, nsage_dir, tsage_append, nsage_append, purple_dir, tlinx_anno_dir, tlinx_plot_dir, nlinx_anno_dir, virusinterpreter_dir, chord_dir, sigs_dir, lilac_dir, cuppa_dir, isofox_dir ]
@@ -204,6 +205,15 @@ workflow ORANGE_REPORTING {
                 meta_orange.tumor_rna_id = Utils.getTumorRnaSampleName(meta)
             } else {
                 rna_tumor_input_indexes.each { i -> inputs_selected[i] = [] }
+            }
+
+            // ORANGE only accepts CUPPA with DNA; when providing DNA/RNA inputs but skipping Virus Interpreter CUPPA
+            // will generate RNA only outputs and no visualisation, which triggers missing file error in ORANGE
+            if (inputs_selected[cuppa_dir_index]) {
+              def cuppa_vis_data_fp = inputs_selected[cuppa_dir_index].resolve("${meta_orange.tumor_id}.cuppa.vis_data.tsv")
+              if (! cuppa_vis_data_fp.exists()) {
+                  inputs_selected[cuppa_dir_index] = []
+              }
             }
 
             assert inputs_selected.size() == input_expected_size

--- a/subworkflows/local/orange_reporting/main.nf
+++ b/subworkflows/local/orange_reporting/main.nf
@@ -210,10 +210,10 @@ workflow ORANGE_REPORTING {
             // ORANGE only accepts CUPPA with DNA; when providing DNA/RNA inputs but skipping Virus Interpreter CUPPA
             // will generate RNA only outputs and no visualisation, which triggers missing file error in ORANGE
             if (inputs_selected[cuppa_dir_index]) {
-              def cuppa_vis_data_fp = inputs_selected[cuppa_dir_index].resolve("${meta_orange.tumor_id}.cuppa.vis_data.tsv")
-              if (! cuppa_vis_data_fp.exists()) {
-                  inputs_selected[cuppa_dir_index] = []
-              }
+                def cuppa_vis_data_fp = inputs_selected[cuppa_dir_index].resolve("${meta_orange.tumor_id}.cuppa.vis_data.tsv")
+                if (! cuppa_vis_data_fp.exists()) {
+                    inputs_selected[cuppa_dir_index] = []
+                }
             }
 
             assert inputs_selected.size() == input_expected_size


### PR DESCRIPTION
**Bug overview**

- ORANGE can only process CUPPA data without error where CUPPA results contain DNA analysis outputs
- CUPPA DNA and RNA analysis components have different input requirements
  - DNA analysis requires: PURPLE, LINX, and VirusInterpreter
  - RNA analysis requires: ISOFOX
- when DNA + RNA inputs are provided but VirusInterpreter is skipped, only the CUPPA RNA analysis component is run
- these CUPPA results do not include DNA analysis outputs and are then passed to ORANGE triggering an error

**Fix**

- this bug is fixed by only providing CUPPA results to ORANGE where the results contain DNA analysis outputs
- the availability of DNA analysis outputs is evaluated by the presence / absence of the  `<tumor>.cuppa.vis_data.tsv` file