### PR TITLE
Switch to bwa-plus from bwa-mem2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [dev]
 
+- [210](https://github.com/nf-core/oncoanalyser/pull/210) - Switch to bwa-plus from bwa-mem2
 - [207](https://github.com/nf-core/oncoanalyser/pull/207) - Apply minor fixes and updates
   - Update the HMF SAGE PON
   - Bump HMF pipeline resource bundles to 2.1.0--1

--- a/modules/local/bwa-mem2/mem/environment.yml
+++ b/modules/local/bwa-mem2/mem/environment.yml
@@ -4,6 +4,6 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::bwa-mem2=2.2.1
+  - bioconda::hmftools-bwa-plus=1.0.0
   - bioconda::samtools=1.21
   - bioconda::sambamba=1.0.1

--- a/modules/local/bwa-mem2/mem/main.nf
+++ b/modules/local/bwa-mem2/mem/main.nf
@@ -4,8 +4,8 @@ process BWAMEM2_ALIGN {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-4dde50190ae599f2bb2027cb2c8763ea00fb5084:b39930b2feee9b7a3e5cbef88b34f0d5c5f64897-0' :
-        'biocontainers/mulled-v2-4dde50190ae599f2bb2027cb2c8763ea00fb5084:b39930b2feee9b7a3e5cbef88b34f0d5c5f64897-0' }"
+        'https://depot.galaxyproject.org/singularity/hmftools-bwa-plus:1.0.0--h077b44d_0' :
+        'biocontainers/hmftools-bwa-plus:1.0.0--h077b44d_0' }"
 
     input:
     tuple val(meta), path(reads_fwd), path(reads_rev)
@@ -30,7 +30,7 @@ process BWAMEM2_ALIGN {
     """
     ln -fs \$(find -L ${genome_bwamem2_index} -type f) ./
 
-    bwa-mem2 mem \\
+    bwa-plus mem \\
         ${args} \\
         -Y \\
         -K 100000000 \\
@@ -56,7 +56,7 @@ process BWAMEM2_ALIGN {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        bwa-mem2: \$(bwa-mem2 version 2>/dev/null)
+        bwa-plus: \$(bwa-plus version 2>/dev/null)
         sambamba: \$(sambamba --version 2>&1 | sed -n '/^sambamba / { s/^.* //p }' | head -n1)
     END_VERSIONS
     """


### PR DESCRIPTION
#### Background

- there are new optimisatons on [bwa-mem2](https://github.com/bwa-mem2/bwa-mem2) `master` not included in the [current release](https://github.com/bwa-mem2/bwa-mem2/releases/tag/v2.2.1)
- users are reportedly encountering memory-related issues that these optimisations resolve
- maintainers of bwa-mem2 are yet to create a new release
- as an alternative, Hartwig have forked bwa-mem2 as [bwa-plus](https://github.com/hartwigmedical/bwa-plus) and applied all recent optimisations
  - several further improvements planned to be made on this fork

#### Changes

- switch only the bwa-mem2 software to bwa-plus 1.0.0 (contributors: @luan-n-nguyen)
- retain all other references to bwa-mem2 for now