### PR TITLE
Configure RunsOn runner to use large disk

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -71,6 +71,7 @@ jobs:
     runs-on: # use self-hosted runners
       - runs-on=$-nf-test
       - runner=4cpu-linux-x64
+      - disk=large
     strategy:
       fail-fast: false
       matrix:

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_stub": {
         "content": [
-            23,
+            34,
             [
                 "pipeline_info",
                 "pipeline_info/software_versions.yml",
@@ -33,8 +33,27 @@
                 "subject_a/bamtools/subject_a_subject_a.tumor_bamtools/subject_a.tumor.bam_metric.frag_length.tsv",
                 "subject_a/bamtools/subject_a_subject_a.tumor_bamtools/subject_a.tumor.bam_metric.partition_stats.tsv",
                 "subject_a/bamtools/subject_a_subject_a.tumor_bamtools/subject_a.tumor.bam_metric.summary.tsv",
+                "subject_a/chord",
+                "subject_a/chord/subject_a.tumor.chord.mutation_contexts.tsv",
+                "subject_a/chord/subject_a.tumor.chord.prediction.tsv",
+                "subject_a/cider",
+                "subject_a/cider/subject_a.tumor.cider.bam",
+                "subject_a/cider/subject_a.tumor.cider.blastn_match.tsv.gz",
+                "subject_a/cider/subject_a.tumor.cider.layout.gz",
+                "subject_a/cider/subject_a.tumor.cider.locus_stats.tsv",
+                "subject_a/cider/subject_a.tumor.cider.vdj.tsv.gz",
+                "subject_a/cider/subject_a.tumor_rna.cider.bam",
+                "subject_a/cider/subject_a.tumor_rna.cider.blastn_match.tsv.gz",
+                "subject_a/cider/subject_a.tumor_rna.cider.layout.gz",
+                "subject_a/cider/subject_a.tumor_rna.cider.locus_stats.tsv",
+                "subject_a/cider/subject_a.tumor_rna.cider.vdj.tsv.gz",
                 "subject_a/cobalt",
                 "subject_a/cobalt/placeholder",
+                "subject_a/cuppa",
+                "subject_a/cuppa/subject_a.tumor.cuppa.pred_summ.tsv",
+                "subject_a/cuppa/subject_a.tumor.cuppa.vis.png",
+                "subject_a/cuppa/subject_a.tumor.cuppa.vis_data.tsv",
+                "subject_a/cuppa/subject_a.tumor.cuppa_data.tsv.gz",
                 "subject_a/esvee",
                 "subject_a/esvee/assemble",
                 "subject_a/esvee/assemble/subject_a.tumor.esvee.alignment.tsv",
@@ -62,6 +81,8 @@
                 "subject_a/esvee/prep/subject_a.tumor.esvee.prep.junction.tsv",
                 "subject_a/isofox",
                 "subject_a/isofox/placeholder",
+                "subject_a/lilac",
+                "subject_a/lilac/placeholder",
                 "subject_a/linx",
                 "subject_a/linx/germline_annotations",
                 "subject_a/linx/germline_annotations/placeholder",
@@ -81,6 +102,12 @@
                 "subject_a/pave/subject_a.tumor.sage.pave_germline.vcf.gz.tbi",
                 "subject_a/pave/subject_a.tumor.sage.pave_somatic.vcf.gz",
                 "subject_a/pave/subject_a.tumor.sage.pave_somatic.vcf.gz.tbi",
+                "subject_a/peach",
+                "subject_a/peach/subject_a.normal.peach.events.tsv",
+                "subject_a/peach/subject_a.normal.peach.gene.events.tsv",
+                "subject_a/peach/subject_a.normal.peach.haplotypes.all.tsv",
+                "subject_a/peach/subject_a.normal.peach.haplotypes.best.tsv",
+                "subject_a/peach/subject_a.normal.peach.qc.tsv",
                 "subject_a/purple",
                 "subject_a/purple/subject_a.tumor.purple.cnv.gene.tsv",
                 "subject_a/purple/subject_a.tumor.purple.cnv.somatic.tsv",
@@ -111,13 +138,28 @@
                 "subject_a/sage/somatic/subject_a.tumor.sage.bqr.png",
                 "subject_a/sage/somatic/subject_a.tumor.sage.bqr.tsv",
                 "subject_a/sage/somatic/subject_a.tumor.sage.somatic.vcf.gz",
-                "subject_a/sage/somatic/subject_a.tumor.sage.somatic.vcf.gz.tbi"
+                "subject_a/sage/somatic/subject_a.tumor.sage.somatic.vcf.gz.tbi",
+                "subject_a/sigs",
+                "subject_a/sigs/placeholder",
+                "subject_a/teal",
+                "subject_a/teal/subject_a.normal.teal.telbam.bam",
+                "subject_a/teal/subject_a.normal.teal.telbam.bam.bai",
+                "subject_a/teal/subject_a.normal.teal.{tellength.tsv}",
+                "subject_a/teal/subject_a.tumor.teal.breakend.tsv.gz",
+                "subject_a/teal/subject_a.tumor.teal.telbam.bam",
+                "subject_a/teal/subject_a.tumor.teal.telbam.bam.bai",
+                "subject_a/teal/subject_a.tumor.teal.tellength.tsv",
+                "subject_a/virusbreakend",
+                "subject_a/virusbreakend/subject_a.tumor.summary.tsv",
+                "subject_a/virusbreakend/subject_a.tumor.virusbreakend.vcf",
+                "subject_a/virusinterpreter",
+                "subject_a/virusinterpreter/subject_a.tumor.virus.annotated.tsv"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.0"
         },
-        "timestamp": "2025-06-05T15:35:26.796569"
+        "timestamp": "2025-06-11T12:53:28.525304"
     }
 }

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -4,5 +4,4 @@
 ========================================================================================
 */
 
-params.processes_exclude = 'virusinterpreter,cuppa,chord,sigs,lilac,peach,cider,teal'
 aws.client.anonymous = true // fixes S3 access issues on self-hosted runners


### PR DESCRIPTION
#### Background

- the nf-test GitHub Actions workflow uses self-hosted runners via [RunsOn](https://runs-on.com/)
- currently the full pipeline level stub test fails due to insufficient disk space to store Docker images
- to allow the pipeline level stub test to work several processes were previously disabled to reduce disk usage
- the RunsOn runners can be set to use pre-defined [disk configurations](https://runs-on.com/configuration/job-labels/#disk):
  - `disk=default`: 40 GiB
  - `disk=large`: 80 GiB

#### Changes

- configure the RunsOn runner to use a large disk size
- re-enable all processes in the pipeline level stub test