### PR TITLE
Allowed flowcell as entry in info field of samplesheet w/ FASTQ

### DIFF
--- a/lib/Constants.groovy
+++ b/lib/Constants.groovy
@@ -135,6 +135,7 @@ class Constants {
         CANCER_TYPE,
         LANE,
         LIBRARY_ID,
+        FLOWCELL,
         LONGITUDINAL_SAMPLE,
     }
 


### PR DESCRIPTION
Add flowcell as a valid entry in the info field of the samplesheet when starting from FASTQ 

Use case: very useful when samples have been sequenced more than once