### PR TITLE
Add ability to specify entire read group tag in "info" field 

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -42,8 +42,8 @@
             "info": {
                 "type": "string",
                 "description": "",
-                "pattern": "^\\S+$",
-                "errorMessage": "info cannot contain spaces"
+                "pattern": "^\\S.*\\S$|^\\S$",
+                "errorMessage": "info cannot have leading or trailing whitespace"
             },
             "filetype": {
                 "type": "string",

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -42,8 +42,8 @@
             "info": {
                 "type": "string",
                 "description": "",
-                "pattern": "^\\S.*\\S$|^\\S$",
-                "errorMessage": "info cannot have leading or trailing whitespace"
+                "pattern": "^\\S+$",
+                "errorMessage": "info cannot contain spaces"
             },
             "filetype": {
                 "type": "string",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -207,19 +207,22 @@ Currently only gzip compressed, non-interleaved paired-end FASTQ files are curre
 ##### Custom read groups
 
 By default the read group of each aligned FASTQ pair is set to `ID:<sample_id>.<library_id>.<lane>` with
-`SM:<sample_id>`. To take full control of the read group, provide a `read_group` key in the `info` field. The value is
-passed **verbatim** to the aligner, so it must match the aligner's expected syntax and contain at least an `ID:` field:
+`SM:<sample_id>`. To add or override read group fields, provide a `read_group` key in the `info` field as a
+`|`-delimited list of `<TAG>=<value>` [SAM read group fields](https://samtools.github.io/hts-specs/SAMv1.pdf),
+e.g. `read_group:ID=S1.L001|PL=ILLUMINA|PU=HJ7.1|CN=HMF`.
 
-- DNA (BWA-MEM2): tab (`\t`) delimited, e.g. `read_group:@RG\tID:S1.L001\tSM:PATIENT1-T\tPL:ILLUMINA`. The leading
-  `@RG\t` is optional and added automatically when omitted.
-- RNA (STAR): space delimited with no `@RG` prefix, e.g. `read_group:ID:S1.L001 SM:PATIENT1-T PL:ILLUMINA`.
+The fields are aligner-agnostic: the pipeline formats them correctly for BWA-MEM2 (DNA) and STAR (RNA), so the same
+syntax works for both. Notes:
 
-A separate `read_group` may be set for each FASTQ pair (i.e. each `library_id` + `lane`). Output BAM filenames continue
-to use `<sample_id>.<library_id>.<lane>` regardless of any custom read group.
+- `ID` and `SM` are added automatically (defaulting to `<sample_id>.<library_id>.<lane>` and `<sample_id>`
+  respectively) and may be overridden by specifying them explicitly.
+- `<TAG>` must be a two-character SAM read group tag (e.g. `ID`, `SM`, `PL`, `PU`, `LB`, `CN`).
+- A separate `read_group` may be set for each FASTQ pair (i.e. each `library_id` + `lane`).
+- Output BAM filenames continue to use `<sample_id>.<library_id>.<lane>` regardless of any custom read group.
 
 ```csv title="samplesheet.csv"
 group_id,subject_id,sample_id,sample_type,sequence_type,filetype,info,filepath
-PATIENT1,PATIENT1,PATIENT1-T,tumor,dna,fastq,library_id:S1;lane:001;read_group:@RG\tID:S1.L001\tSM:PATIENT1-T\tPL:ILLUMINA,/path/to/PATIENT1-T_S1_L001_R1_001.fastq.gz;/path/to/PATIENT1-T_S1_L001_R2_001.fastq.gz
+PATIENT1,PATIENT1,PATIENT1-T,tumor,dna,fastq,library_id:S1;lane:001;read_group:ID=S1.L001|PL=ILLUMINA|CN=HMF,/path/to/PATIENT1-T_S1_L001_R1_001.fastq.gz;/path/to/PATIENT1-T_S1_L001_R2_001.fastq.gz
 ```
 
 #### BAM

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -169,7 +169,7 @@ row as the first line with the below columns:
 | `sample_type`   | Sample type: `tumor`, `normal`, or `tumor_normal`                                                                                                                                                                                                                                                                                                                 |
 | `sequence_type` | Sequence type: `dna`, `rna`, or `dna_rna`                                                                                                                                                                                                                                                                                                                         |
 | `filetype`      | File type: e.g. `fastq`, `bam`, `bai`. All valid values can be found [here](../lib/samplesheet/FileType.groovy).                                                                                                                                                                                                                                                  |
-| `info`          | Additional sample info in the form `<key1>:<value1>;<key1>:<value2>;...`. Valid keys: `lane` and `library_id` for [FASTQ](#fastq) files, `longitudinal_sample` for mode [purity_estimate](#purity-estimate), `cancer_type` as a DOID that is passed to ORANGE (details in [readme](https://github.com/hartwigmedical/hmftools/tree/master/orange#running-orange)) |
+| `info`          | Additional sample info in the form `<key1>:<value1>;<key1>:<value2>;...`. Valid keys: `lane` and `library_id` for [FASTQ](#fastq) files, `read_group` to set a custom read group tag for [FASTQ](#fastq) files (see [below](#custom-read-groups)), `longitudinal_sample` for mode [purity_estimate](#purity-estimate), `cancer_type` as a DOID that is passed to ORANGE (details in [readme](https://github.com/hartwigmedical/hmftools/tree/master/orange#running-orange)) |
 | `filepath`      | Absolute filepath to input file. Can be a local path, URL (e.g. http://, https://, ftp://) or cloud URI (e.g. gs://, s3://)                                                                                                                                                                                                                                       |
 
 Output file paths are constructed based on `group_id` and `sample_id`:
@@ -203,6 +203,24 @@ PATIENT1,PATIENT1,PATIENT1-T,tumor,dna,fastq,library_id:S1;lane:002,/path/to/PAT
 Currently only gzip compressed, non-interleaved paired-end FASTQ files are currently supported.
 
 :::
+
+##### Custom read groups
+
+By default the read group of each aligned FASTQ pair is set to `ID:<sample_id>.<library_id>.<lane>` with
+`SM:<sample_id>`. To take full control of the read group, provide a `read_group` key in the `info` field. The value is
+passed **verbatim** to the aligner, so it must match the aligner's expected syntax and contain at least an `ID:` field:
+
+- DNA (BWA-MEM2): tab (`\t`) delimited, e.g. `read_group:@RG\tID:S1.L001\tSM:PATIENT1-T\tPL:ILLUMINA`. The leading
+  `@RG\t` is optional and added automatically when omitted.
+- RNA (STAR): space delimited with no `@RG` prefix, e.g. `read_group:ID:S1.L001 SM:PATIENT1-T PL:ILLUMINA`.
+
+A separate `read_group` may be set for each FASTQ pair (i.e. each `library_id` + `lane`). Output BAM filenames continue
+to use `<sample_id>.<library_id>.<lane>` regardless of any custom read group.
+
+```csv title="samplesheet.csv"
+group_id,subject_id,sample_id,sample_type,sequence_type,filetype,info,filepath
+PATIENT1,PATIENT1,PATIENT1-T,tumor,dna,fastq,library_id:S1;lane:001;read_group:@RG\tID:S1.L001\tSM:PATIENT1-T\tPL:ILLUMINA,/path/to/PATIENT1-T_S1_L001_R1_001.fastq.gz;/path/to/PATIENT1-T_S1_L001_R2_001.fastq.gz
+```
 
 #### BAM
 

--- a/lib/samplesheet/InfoField.groovy
+++ b/lib/samplesheet/InfoField.groovy
@@ -6,7 +6,8 @@ public enum InfoField {
     CANCER_TYPE,
     LANE,
     LIBRARY_ID,
-    LONGITUDINAL_SAMPLE;
+    LONGITUDINAL_SAMPLE,
+    READ_GROUP;
 
     public static InfoField fromString(String string) {
         return Enums.getValidatedEnumFromString(string, InfoField)

--- a/lib/samplesheet/SampleSheet.groovy
+++ b/lib/samplesheet/SampleSheet.groovy
@@ -121,7 +121,11 @@ class SampleSheet {
         entry.info
             .tokenize(';')
             .each { info_item ->
-                def (info_key, info_value) = info_item.tokenize(':')
+                // NOTE(PW): split on the first ':' only so that values may themselves contain ':'
+                // (e.g. a custom read_group tag such as 'ID:foo\tSM:bar')
+                def sep_index = info_item.indexOf(':')
+                def info_key = sep_index == -1 ? info_item : info_item.substring(0, sep_index)
+                def info_value = sep_index == -1 ? null : info_item.substring(sep_index + 1)
                 def info_field = InfoField.fromString(info_key)
 
                 if (info_data.containsKey(info_field)) {
@@ -173,6 +177,12 @@ class SampleSheet {
             throw new IllegalStateException("Missing 'lane' info field for group_id(${entry.group_id}) sample_id(${entry.sample_id})")
         }
 
+        // A custom read_group tag is passed verbatim to the aligner; require at minimum an 'ID:' field so
+        // that BWA-MEM2 / STAR do not fail with a cryptic error
+        if (info_data.containsKey(InfoField.READ_GROUP) && !info_data[InfoField.READ_GROUP].contains('ID:')) {
+            throw new IllegalStateException("Custom read_group must contain an 'ID:' field for group_id(${entry.group_id}) sample_id(${entry.sample_id})")
+        }
+
         def fastq_entries = entry.filepath.tokenize(';')
 
         if (fastq_entries.size() != 2) {
@@ -193,7 +203,12 @@ class SampleSheet {
             throw new IllegalStateException("Got duplicate lane + library_id data for group_id(${entry.group_id}) sample_id(${entry.sample_id}): ${fastq_key}")
         }
 
-        meta_sample[FileType.FASTQ][fastq_key] = ['fwd': getFileObject(fwd), 'rev': getFileObject(rev)]
+        // NOTE(PW): read_group is an optional verbatim aligner read group tag; null when not provided
+        meta_sample[FileType.FASTQ][fastq_key] = [
+            'fwd': getFileObject(fwd),
+            'rev': getFileObject(rev),
+            'read_group': info_data[InfoField.READ_GROUP],
+        ]
 
     }
 

--- a/lib/samplesheet/SampleSheet.groovy
+++ b/lib/samplesheet/SampleSheet.groovy
@@ -121,11 +121,7 @@ class SampleSheet {
         entry.info
             .tokenize(';')
             .each { info_item ->
-                // NOTE(PW): split on the first ':' only so that values may themselves contain ':'
-                // (e.g. a custom read_group tag such as 'ID:foo\tSM:bar')
-                def sep_index = info_item.indexOf(':')
-                def info_key = sep_index == -1 ? info_item : info_item.substring(0, sep_index)
-                def info_value = sep_index == -1 ? null : info_item.substring(sep_index + 1)
+                def (info_key, info_value) = info_item.tokenize(':')
                 def info_field = InfoField.fromString(info_key)
 
                 if (info_data.containsKey(info_field)) {
@@ -177,12 +173,6 @@ class SampleSheet {
             throw new IllegalStateException("Missing 'lane' info field for group_id(${entry.group_id}) sample_id(${entry.sample_id})")
         }
 
-        // A custom read_group tag is passed verbatim to the aligner; require at minimum an 'ID:' field so
-        // that BWA-MEM2 / STAR do not fail with a cryptic error
-        if (info_data.containsKey(InfoField.READ_GROUP) && !info_data[InfoField.READ_GROUP].contains('ID:')) {
-            throw new IllegalStateException("Custom read_group must contain an 'ID:' field for group_id(${entry.group_id}) sample_id(${entry.sample_id})")
-        }
-
         def fastq_entries = entry.filepath.tokenize(';')
 
         if (fastq_entries.size() != 2) {
@@ -203,13 +193,58 @@ class SampleSheet {
             throw new IllegalStateException("Got duplicate lane + library_id data for group_id(${entry.group_id}) sample_id(${entry.sample_id}): ${fastq_key}")
         }
 
-        // NOTE(PW): read_group is an optional verbatim aligner read group tag; null when not provided
+        // NOTE(PW): read_group is an optional set of SAM read group fields (e.g. 'ID=..|PL=..'); null when not provided.
+        // It is stored aligner-agnostically and formatted per-aligner downstream (BWA-MEM2 / STAR).
+        def read_group_fields = info_data.containsKey(InfoField.READ_GROUP)
+            ? parseReadGroupFields(info_data[InfoField.READ_GROUP], entry)
+            : null
+
         meta_sample[FileType.FASTQ][fastq_key] = [
             'fwd': getFileObject(fwd),
             'rev': getFileObject(rev),
-            'read_group': info_data[InfoField.READ_GROUP],
+            'read_group_fields': read_group_fields,
         ]
 
+    }
+
+    private static Map parseReadGroupFields(String read_group, Map<String, String> entry) {
+
+        // Parse a custom read group provided as '|'-delimited 'TAG=value' SAM fields (e.g. 'ID=S1.L001|PL=ILLUMINA').
+        // Returns an ordered map of tag -> value, leaving aligner-specific formatting to the alignment modules.
+        def fields = [:]
+
+        read_group.tokenize('|').each { field_item ->
+
+            def sep_index = field_item.indexOf('=')
+
+            if (sep_index < 1 || sep_index == field_item.length() - 1) {
+                throw new IllegalStateException(
+                    "Invalid read_group field('${field_item}') for group_id(${entry.group_id}) sample_id(${entry.sample_id}): " +
+                    "expected '<TAG>=<value>' (e.g. 'ID=S1.L001|PL=ILLUMINA')"
+                )
+            }
+
+            def tag = field_item.substring(0, sep_index)
+            def value = field_item.substring(sep_index + 1)
+
+            // SAM read group tags are two characters matching /[A-Za-z][A-Za-z0-9]/
+            if (!(tag ==~ /[A-Za-z][A-Za-z0-9]/)) {
+                throw new IllegalStateException(
+                    "Invalid read_group tag('${tag}') for group_id(${entry.group_id}) sample_id(${entry.sample_id}): " +
+                    "SAM read group tags are two characters (e.g. ID, SM, PL, PU, LB, CN)"
+                )
+            }
+
+            if (fields.containsKey(tag)) {
+                throw new IllegalStateException(
+                    "Duplicate read_group tag('${tag}') for group_id(${entry.group_id}) sample_id(${entry.sample_id})"
+                )
+            }
+
+            fields[tag] = value
+        }
+
+        return fields
     }
 
     private static void setCramPaths(Map meta_sample) {

--- a/modules/local/bwa-mem2/mem/main.nf
+++ b/modules/local/bwa-mem2/mem/main.nf
@@ -25,14 +25,13 @@ process BWAMEM2_ALIGN {
     def args2 = task.ext.args2 ?: ''
     def args3 = task.ext.args3 ?: ''
 
-    // A custom read group (set via the 'read_group' samplesheet info field) is passed verbatim; otherwise
-    // build the default tag. The '@RG' prefix required by `-R` is added automatically when absent.
-    def read_group_tag
-    if (meta.read_group_custom) {
-        read_group_tag = meta.read_group_custom.startsWith('@RG') ? meta.read_group_custom : "@RG\\t${meta.read_group_custom}"
-    } else {
-        read_group_tag = "@RG\\tID:${meta.read_group}\\tSM:${meta.sample_id}"
-    }
+    // Build the @RG tag (tab-delimited). Extra/override SAM fields may be supplied via the 'read_group'
+    // samplesheet info field (e.g. 'ID=..|PL=..'); ID and SM default to the sample/library/lane identifiers.
+    def rg_fields = meta.read_group_fields ?: [:]
+    def rg_id = rg_fields.ID ?: meta.read_group
+    def rg_sm = rg_fields.SM ?: meta.sample_id
+    def rg_extra = rg_fields.findAll { k, v -> k != 'ID' && k != 'SM' }.collect { k, v -> "${k}:${v}" }
+    def read_group_tag = (["@RG", "ID:${rg_id}", "SM:${rg_sm}"] + rg_extra).join('\\t')
     def output_fn = meta.split ? "${meta.split}.${meta.sample_id}.${meta.read_group}.bam" : "${meta.sample_id}.${meta.read_group}.bam"
 
     """

--- a/modules/local/bwa-mem2/mem/main.nf
+++ b/modules/local/bwa-mem2/mem/main.nf
@@ -25,7 +25,14 @@ process BWAMEM2_ALIGN {
     def args2 = task.ext.args2 ?: ''
     def args3 = task.ext.args3 ?: ''
 
-    def read_group_tag = "@RG\\tID:${meta.read_group}\\tSM:${meta.sample_id}"
+    // A custom read group (set via the 'read_group' samplesheet info field) is passed verbatim; otherwise
+    // build the default tag. The '@RG' prefix required by `-R` is added automatically when absent.
+    def read_group_tag
+    if (meta.read_group_custom) {
+        read_group_tag = meta.read_group_custom.startsWith('@RG') ? meta.read_group_custom : "@RG\\t${meta.read_group_custom}"
+    } else {
+        read_group_tag = "@RG\\tID:${meta.read_group}\\tSM:${meta.sample_id}"
+    }
     def output_fn = meta.split ? "${meta.split}.${meta.sample_id}.${meta.read_group}.bam" : "${meta.sample_id}.${meta.read_group}.bam"
 
     """

--- a/modules/local/star/align/main.nf
+++ b/modules/local/star/align/main.nf
@@ -22,6 +22,16 @@ process STAR_ALIGN {
     script:
     def args = task.ext.args ?: ''
 
+    // A custom read group (set via the 'read_group' samplesheet info field) is passed verbatim; otherwise
+    // build the default line. STAR expects space-separated 'KEY:VALUE' attributes with no '@RG' prefix, so
+    // strip the prefix if the user supplied one.
+    def read_group_line
+    if (meta.read_group_custom) {
+        read_group_line = meta.read_group_custom.replaceFirst(/^@RG\s+/, '')
+    } else {
+        read_group_line = "ID:${meta.read_group} SM:${meta.sample_id}"
+    }
+
     """
     STAR \\
         ${args} \\
@@ -48,7 +58,7 @@ process STAR_ALIGN {
         --outFilterMultimapNmax 10 \\
         --outFilterScoreMinOverLread 0.33 \\
         --outSAMattributes All \\
-        --outSAMattrRGline ID:${meta.read_group} SM:${meta.sample_id} \\
+        --outSAMattrRGline ${read_group_line} \\
         --outSAMtype BAM Unsorted \\
         --outSAMunmapped Within \\
         --peOverlapNbasesMin 10 \\

--- a/modules/local/star/align/main.nf
+++ b/modules/local/star/align/main.nf
@@ -22,15 +22,14 @@ process STAR_ALIGN {
     script:
     def args = task.ext.args ?: ''
 
-    // A custom read group (set via the 'read_group' samplesheet info field) is passed verbatim; otherwise
-    // build the default line. STAR expects space-separated 'KEY:VALUE' attributes with no '@RG' prefix, so
-    // strip the prefix if the user supplied one.
-    def read_group_line
-    if (meta.read_group_custom) {
-        read_group_line = meta.read_group_custom.replaceFirst(/^@RG\s+/, '')
-    } else {
-        read_group_line = "ID:${meta.read_group} SM:${meta.sample_id}"
-    }
+    // Build the read group line. Extra/override SAM fields may be supplied via the 'read_group' samplesheet
+    // info field (e.g. 'ID=..|PL=..'); ID and SM default to the sample/library/lane identifiers. STAR expects
+    // space-separated 'KEY:VALUE' attributes with no '@RG' prefix.
+    def rg_fields = meta.read_group_fields ?: [:]
+    def rg_id = rg_fields.ID ?: meta.read_group
+    def rg_sm = rg_fields.SM ?: meta.sample_id
+    def rg_extra = rg_fields.findAll { k, v -> k != 'ID' && k != 'SM' }.collect { k, v -> "${k}:${v}" }
+    def read_group_line = (["ID:${rg_id}", "SM:${rg_sm}"] + rg_extra).join(' ')
 
     """
     STAR \\

--- a/subworkflows/local/read_alignment_dna/main.nf
+++ b/subworkflows/local/read_alignment_dna/main.nf
@@ -77,7 +77,7 @@ workflow READ_ALIGNMENT_DNA {
                         library_id: library_id,
                         lane: lane,
                         sample_type: sample_type,
-                        read_group_custom: fps['read_group'],
+                        read_group_fields: fps['read_group_fields'],
                     ]
 
                     return [meta_fastq, fps['fwd'], fps['rev']]

--- a/subworkflows/local/read_alignment_dna/main.nf
+++ b/subworkflows/local/read_alignment_dna/main.nf
@@ -77,6 +77,7 @@ workflow READ_ALIGNMENT_DNA {
                         library_id: library_id,
                         lane: lane,
                         sample_type: sample_type,
+                        read_group_custom: fps['read_group'],
                     ]
 
                     return [meta_fastq, fps['fwd'], fps['rev']]
@@ -119,6 +120,7 @@ workflow READ_ALIGNMENT_DNA {
 
     //
     // Split FASTQ into chunks if requested for distributed processing
+    
     //
     // channel: [ meta_fastq_ready, fastq_fwd, fastq_rev ]
     ch_fastqs_ready = Channel.empty()

--- a/subworkflows/local/read_alignment_rna/main.nf
+++ b/subworkflows/local/read_alignment_rna/main.nf
@@ -51,7 +51,7 @@ workflow READ_ALIGNMENT_RNA {
                         sample_id: meta_sample.sample_id,
                         library_id: library_id,
                         lane: lane,
-                        read_group_custom: fps['read_group'],
+                        read_group_fields: fps['read_group_fields'],
                     ]
 
                     return [meta_fastq, fps['fwd'], fps['rev']]

--- a/subworkflows/local/read_alignment_rna/main.nf
+++ b/subworkflows/local/read_alignment_rna/main.nf
@@ -51,6 +51,7 @@ workflow READ_ALIGNMENT_RNA {
                         sample_id: meta_sample.sample_id,
                         library_id: library_id,
                         lane: lane,
+                        read_group_custom: fps['read_group'],
                     ]
 
                     return [meta_fastq, fps['fwd'], fps['rev']]


### PR DESCRIPTION
 Use a |-delimited list of TAG=value SAM fields (e.g. read_group:ID=S1.L001|PL=ILLUMINA). Thefields are stored aligner-agnostically and formatted per-aligner so the same syntax works for both BWA-MEM2 (DNA) and STAR (RNA), rather than
requiring users to match each aligner's read group syntax. ID and SM default to the sample/library/lane identifiers and may be overridden.