### PR TITLE
Dev 3.0.0 align from bam

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -248,6 +248,11 @@ used throughout the WiGiTS tools). We plan to address this issue in future relea
 
 :::
 
+#### RUN FROM BAM OR CRAM BUT REALIGN
+
+To run from BAM or CRAM that doesn't meet Oncoanalyser's input requirements, specify `bam` or `cram` in the `filetype` field and prepare a samplesheet as above for BAM or CRAM, but add the `--realign_bam` parameter. This will behave more like the fastq mode, but efficiently streaming directly from the input BAM/CRAM into bwa-mem. 
+
+
 #### REDUX BAM / CRAM
 
 When running an analysis with DNA data from FASTQ, two of the most time consuming and resource intensive pipeline steps

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -169,6 +169,12 @@ class Utils {
 
                 // Check that required indexes are provided or are accessible
                 sample_keys.each { sample_key ->
+                    
+                    // In realign mode, BAM/CRAM inputs are streamed through samtools for re-alignment,
+                    // so we do not require pre-existing BAM/CRAM index files from the sample sheet.
+                    if (params.realign_bam) {
+                        return
+                    }
 
                     meta[sample_key]*.key.each { key ->
 

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -6,7 +6,7 @@ import nextflow.Nextflow
 
 class Utils {
 
-    public static parseInput(input_fp_str, stub_run, log) {
+    public static parseInput(input_fp_str, stub_run, realign_bam, log) {
 
         if (!input_fp_str) {
             log.error "Missing required --input argument"
@@ -172,7 +172,7 @@ class Utils {
                     
                     // In realign mode, BAM/CRAM inputs are streamed through samtools for re-alignment,
                     // so we do not require pre-existing BAM/CRAM index files from the sample sheet.
-                    if (params.realign_bam) {
+                    if (realign_bam) {
                         return
                     }
 

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -422,9 +422,9 @@ class Utils {
                 Nextflow.exit(1)
             }
 
-            // Do not allow CRAM RNA input
-            if (Utils.hasTumorRnaBam(meta) && Utils.getTumorRnaBam(meta).toString().endsWith('cram')) {
-                log.error "found tumor RNA CRAM input for ${meta.group_id} but RNA CRAM input is not supported"
+            // Do not allow CRAM RNA input unless realign_bam is true
+            if (Utils.hasTumorRnaBam(meta) && Utils.getTumorRnaBam(meta).toString().endsWith('cram') && !params.realign_bam) {
+                log.error "found tumor RNA CRAM input for ${meta.group_id} but RNA CRAM input is only supported if realigning"
                 Nextflow.exit(1)
             }
 

--- a/lib/WorkflowMain.groovy
+++ b/lib/WorkflowMain.groovy
@@ -315,24 +315,34 @@ class WorkflowMain {
 
     public static getRunConfig(params, inputs, log) {
 
-        def run_mode = Utils.getRunMode(params.mode, log)
+    def run_mode = Utils.getRunMode(params.mode, log)
 
-        def stages = Processes.getRunStages(
-            params.processes_include,
-            params.processes_exclude,
-            params.processes_manual,
-            log,
-        )
+    def stages = Processes.getRunStages(
+        params.processes_include,
+        params.processes_exclude,
+        params.processes_manual,
+        log,
+    )
 
-        return [
-            mode: run_mode,
-            stages: stages,
-            has_dna: inputs.any { Utils.hasTumorDna(it) },
-            has_rna: inputs.any { Utils.hasTumorRna(it) },
-            has_rna_fastq: inputs.any { Utils.hasTumorRnaFastq(it) },
-            has_dna_fastq: inputs.any { Utils.hasTumorDnaFastq(it) || Utils.hasNormalDnaFastq(it) },
-        ]
+    def has_dna_bam = inputs.any { Utils.hasTumorDnaBam(it) || Utils.hasNormalDnaBam(it) || Utils.hasDonorDnaBam(it) }
+    def has_rna_bam = inputs.any { Utils.hasTumorRnaBam(it) }
+
+    // Force alignment when realign mode is requested and BAM/CRAM exists
+    if (params.realign_bam && (has_dna_bam || has_rna_bam)) {
+        stages.alignment = true
     }
+
+    return [
+        mode: run_mode,
+        stages: stages,
+        has_dna: inputs.any { Utils.hasTumorDna(it) },
+        has_rna: inputs.any { Utils.hasTumorRna(it) },
+        has_rna_fastq: inputs.any { Utils.hasTumorRnaFastq(it) },
+        has_dna_fastq: inputs.any { Utils.hasTumorDnaFastq(it) || Utils.hasNormalDnaFastq(it) },
+        has_dna_bam: has_dna_bam,
+        has_rna_bam: has_rna_bam,
+    ]
+}
 
     public static getPrepConfigFromSamplesheet(run_config) {
         return [
@@ -343,8 +353,8 @@ class WorkflowMain {
             require_dict: true,
             require_img: true,
 
-            require_bwamem2_index: run_config.has_dna_fastq && run_config.stages.alignment,
-            require_star_index: run_config.has_rna_fastq && run_config.stages.alignment,
+            require_bwamem2_index: run_config.stages.alignment && (run_config.has_dna_fastq || (params.realign_bam && run_config.has_dna_bam)),
+            require_star_index:    run_config.stages.alignment && (run_config.has_rna_fastq || (params.realign_bam && run_config.has_rna_bam)),
 
             require_gridss_index: run_config.has_dna && run_config.mode === Constants.RunMode.WGTS && run_config.stages.virusinterpreter,
             require_hmftools_data: true,

--- a/lib/WorkflowMain.groovy
+++ b/lib/WorkflowMain.groovy
@@ -345,10 +345,9 @@ class WorkflowMain {
 }
 
     public static getPrepConfigFromSamplesheet(run_config, params = null) {
+        def realign_bam = params.containsKey('realign_bam') && params.realign_bam
         return [
             prepare_ref_data_only: false,
-            def realign_bam = (params != null && params.containsKey('realign_bam') && params.realign_bam) || run_config.getOrDefault('realign_bam', false)
-
             require_fasta: true,
             require_fai: true,
             require_dict: true,

--- a/lib/WorkflowMain.groovy
+++ b/lib/WorkflowMain.groovy
@@ -344,17 +344,18 @@ class WorkflowMain {
     ]
 }
 
-    public static getPrepConfigFromSamplesheet(run_config) {
+    public static getPrepConfigFromSamplesheet(run_config, params = null) {
         return [
             prepare_ref_data_only: false,
+            def realign_bam = (params != null && params.containsKey('realign_bam') && params.realign_bam) || run_config.getOrDefault('realign_bam', false)
 
             require_fasta: true,
             require_fai: true,
             require_dict: true,
             require_img: true,
 
-            require_bwamem2_index: run_config.stages.alignment && (run_config.has_dna_fastq || (params.realign_bam && run_config.has_dna_bam)),
-            require_star_index:    run_config.stages.alignment && (run_config.has_rna_fastq || (params.realign_bam && run_config.has_rna_bam)),
+            require_bwamem2_index: run_config.stages.alignment && (run_config.has_dna_fastq || (realign_bam && run_config.has_dna_bam)),
+            require_star_index: run_config.stages.alignment && (run_config.has_rna_fastq || (realign_bam && run_config.has_rna_bam)),
 
             require_gridss_index: run_config.has_dna && run_config.mode === Constants.RunMode.WGTS && run_config.stages.virusinterpreter,
             require_hmftools_data: true,

--- a/main.nf
+++ b/main.nf
@@ -85,7 +85,7 @@ workflow NFCORE_ONCOANALYSER {
         PREPARE_REFERENCE()
     } else {
         // Parse and validate inputs
-        inputs = Utils.parseInput(params.input, workflow.stubRun, log)
+        inputs = Utils.parseInput(params.input, workflow.stubRun, params.realign_bam, log)
         run_config = WorkflowMain.getRunConfig(params, inputs, log)
         Utils.validateInput(inputs, run_config, params, log)
 

--- a/modules/local/bwa-mem2/mem_from_bam/environment.yml
+++ b/modules/local/bwa-mem2/mem_from_bam/environment.yml
@@ -1,7 +1,8 @@
-name: star_align
+name: bwa-mem2_mem
 channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::star=2.7.3a
+  - bioconda::bwa-mem2=2.3
   - bioconda::samtools=1.21
+  - bioconda::sambamba=1.0.1

--- a/modules/local/bwa-mem2/mem_from_bam/main.nf
+++ b/modules/local/bwa-mem2/mem_from_bam/main.nf
@@ -33,6 +33,10 @@ process BWAMEM2_ALIGN_FROM_BAM {
 
     samtools fastq \\
         -@ ${task.cpus} \\
+        -n \\
+        -F 0x900 \\
+        -1 /dev/stdout \\
+        -2 /dev/stdout \\    
         -0 /dev/null \\
         -s /dev/null \\
         ${bam_input} | \\

--- a/modules/local/bwa-mem2/mem_from_bam/main.nf
+++ b/modules/local/bwa-mem2/mem_from_bam/main.nf
@@ -36,7 +36,7 @@ process BWAMEM2_ALIGN_FROM_BAM {
         -n \\
         -F 0x900 \\
         -1 /dev/stdout \\
-        -2 /dev/stdout \\    
+        -2 /dev/stdout \\
         -0 /dev/null \\
         -s /dev/null \\
         ${bam_input} | \\
@@ -64,6 +64,11 @@ process BWAMEM2_ALIGN_FROM_BAM {
         --nthreads ${task.cpus} \\
         --out ${output_fn} \\
         /dev/stdin
+
+    # Force non-empty output check (helps catch upstream empty input quickly)
+    test -s ${output_fn}
+    samtools quickcheck ${output_fn}
+    samtools index -@ ${task.cpus} ${output_fn}
 
     # NOTE(SW): bwa-mem2 version hardcoded as 2.3 reports the wrong version
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/bwa-mem2/mem_from_bam/main.nf
+++ b/modules/local/bwa-mem2/mem_from_bam/main.nf
@@ -32,6 +32,7 @@ process BWAMEM2_ALIGN_FROM_BAM {
     ln -fs \$(find -L ${genome_bwamem2_index} -type f) ./
 
     samtools collate \\
+        -O \\
         -@ ${task.cpus} \\
         ${bam_input} | \\
     samtools fastq \\

--- a/modules/local/bwa-mem2/mem_from_bam/main.nf
+++ b/modules/local/bwa-mem2/mem_from_bam/main.nf
@@ -1,0 +1,81 @@
+process BWAMEM2_ALIGN_FROM_BAM {
+    tag "${meta.id}"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mulled-v2-4dde50190ae599f2bb2027cb2c8763ea00fb5084:596c0d6a494faa218562f2be03af2714d454da4f-0' :
+        'biocontainers/mulled-v2-4dde50190ae599f2bb2027cb2c8763ea00fb5084:596c0d6a494faa218562f2be03af2714d454da4f-0' }"
+
+    input:
+    tuple val(meta), path(bam_input)        // BAM or CRAM to be realigned
+    path genome_fasta
+    path genome_bwamem2_index
+
+    output:
+    tuple val(meta), path('*.bam'), path('*.bai'), emit: bam
+    path 'versions.yml'                           , emit: versions
+    path '.command.*'                             , emit: command_files
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args  = task.ext.args  ?: ''
+    def args2 = task.ext.args2 ?: ''
+    def args3 = task.ext.args3 ?: ''
+
+    def read_group_tag = "@RG\\tID:${meta.read_group}\\tSM:${meta.sample_id}"
+    def output_fn = "${meta.sample_id}.${meta.read_group}.bam"
+
+    """
+    ln -fs \$(find -L ${genome_bwamem2_index} -type f) ./
+
+    samtools fastq \\
+        -@ ${task.cpus} \\
+        -0 /dev/null \\
+        -s /dev/null \\
+        ${bam_input} | \\
+    \\
+    bwa-mem2 mem \\
+        ${args} \\
+        -Y \\
+        -K 100000000 \\
+        -p \\
+        -R '${read_group_tag}' \\
+        -t ${task.cpus} \\
+        ${genome_fasta} \\
+        /dev/stdin | \\
+    \\
+    sambamba view \\
+        ${args2} \\
+        --sam-input \\
+        --format bam \\
+        --compression-level 0 \\
+        --nthreads ${task.cpus} \\
+        /dev/stdin | \\
+    \\
+    sambamba sort \\
+        ${args3} \\
+        --nthreads ${task.cpus} \\
+        --out ${output_fn} \\
+        /dev/stdin
+
+    # NOTE(SW): bwa-mem2 version hardcoded as 2.3 reports the wrong version
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bwa-mem2: 2.3
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+        sambamba: \$(sambamba --version 2>&1 | sed -n '/^sambamba / { s/^.* //p }' | head -n1)
+    END_VERSIONS
+    """
+
+    stub:
+    def output_fn = "${meta.sample_id}.${meta.read_group}.bam"
+    """
+    touch ${output_fn}
+    touch ${output_fn}.bai
+
+    echo -e '${task.process}:\\n  stub: noversions\\n' > versions.yml
+    """
+}

--- a/modules/local/bwa-mem2/mem_from_bam/main.nf
+++ b/modules/local/bwa-mem2/mem_from_bam/main.nf
@@ -31,6 +31,9 @@ process BWAMEM2_ALIGN_FROM_BAM {
     """
     ln -fs \$(find -L ${genome_bwamem2_index} -type f) ./
 
+    samtools collate \\
+        -@ ${task.cpus} \\
+        ${bam_input} | \\
     samtools fastq \\
         -@ ${task.cpus} \\
         -n \\
@@ -39,7 +42,7 @@ process BWAMEM2_ALIGN_FROM_BAM {
         -2 /dev/stdout \\
         -0 /dev/null \\
         -s /dev/null \\
-        ${bam_input} | \\
+        - | \\
     \\
     bwa-mem2 mem \\
         ${args} \\

--- a/modules/local/bwa-mem2/mem_from_bam/meta.yml
+++ b/modules/local/bwa-mem2/mem_from_bam/meta.yml
@@ -1,0 +1,51 @@
+name: bwa-mem2_mem_from_bam
+description: The mem alignment algorithm of bwa-mem2, piping reads directly from BAM/CRAM files instead of FASTQ files
+keywords:
+  - bwa
+  - mem
+  - read alignment
+  - bwa-mem2
+tools:
+  - bwa-mem2:
+      description: Burrow-Wheeler Aligner for short-read alignment
+      homepage: https://github.com/bwa-mem2/bwa-mem2
+      documentation: https://github.com/bwa-mem2/bwa-mem2
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [id: 'sample_id']
+  - bam_input:
+        type: file
+        description: Input coordinate-sorted BAM or CRAM to be realigned.
+        pattern: "*.{bam,cram}"
+  - genome_fasta:
+      type: file
+      description: Reference genome assembly FASTA file
+      pattern: "*.{fa,fasta}"
+  - genome_bwamem2_index:
+      type: directory
+      description: bwa-mem2 index directory
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [id: 'sample_id']
+  - bam:
+      type: list
+      description: BAM and BAI file
+      pattern: "*.{bam,bam.bai}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - command_files:
+      type: list
+      description: List of command files
+authors:
+  - "@scwatts"
+  - "@mkcmkc"
+  - "@oneillkza"

--- a/modules/local/star/align_from_bam/environment.yml
+++ b/modules/local/star/align_from_bam/environment.yml
@@ -4,3 +4,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::star=2.7.3a
+  - bioconda::samtools=1.21

--- a/modules/local/star/align_from_bam/main.nf
+++ b/modules/local/star/align_from_bam/main.nf
@@ -12,7 +12,7 @@ process STAR_ALIGN_FROM_BAM {
     path genome_star_index
 
     output:
-    tuple val(meta), path('*bam'), emit: bam
+    tuple val(meta), path('Aligned.out.bam'), emit: bam
     path 'versions.yml'          , emit: versions
     path '.command.*'            , emit: command_files
 

--- a/modules/local/star/align_from_bam/main.nf
+++ b/modules/local/star/align_from_bam/main.nf
@@ -27,13 +27,16 @@ process STAR_ALIGN_FROM_BAM {
     mkfifo r1.fifo r2.fifo
 
     # Feed samtools fastq into the two FIFOs in the background
+     samtools collate \\
+        -@ ${task.cpus} \\
+        ${bam_input} | \\
     samtools fastq \\
         -@ ${task.cpus} \\
         -1 r1.fifo \\
         -2 r2.fifo \\
         -0 /dev/null \\
         -s /dev/null \\
-        ${bam_input} &
+        - &
 
     STAR \\
         ${args} \\

--- a/modules/local/star/align_from_bam/main.nf
+++ b/modules/local/star/align_from_bam/main.nf
@@ -23,21 +23,23 @@ process STAR_ALIGN_FROM_BAM {
     def args = task.ext.args ?: ''
 
     """
+
+    # Create a collated version of the bam on local disk (annoying use of disk, but it's RNA so likely not so big)
+    # Unfortunately there's a FIFO deadlock if this is all piped together
+    samtools collate -@ ${task.cpus} -O -o collated.bam ${bam_input}
+
+
     # Create named FIFOs for R1 and R2
     mkfifo r1.fifo r2.fifo
 
     # Feed samtools fastq into the two FIFOs in the background
-     samtools collate \\
-        -O \\
-        -@ ${task.cpus} \\
-        ${bam_input} | \\
     samtools fastq \\
         -@ ${task.cpus} \\
         -1 r1.fifo \\
         -2 r2.fifo \\
         -0 /dev/null \\
         -s /dev/null \\
-        - &
+        collated.bam &
 
     STAR \\
         ${args} \\

--- a/modules/local/star/align_from_bam/main.nf
+++ b/modules/local/star/align_from_bam/main.nf
@@ -28,22 +28,11 @@ process STAR_ALIGN_FROM_BAM {
     # Unfortunately there's a FIFO deadlock if this is all piped together
     samtools collate -@ ${task.cpus} -u -o collated.bam ${bam_input}
 
-
-    # Create named FIFOs for R1 and R2
-    mkfifo r1.fifo r2.fifo
-
-    # Feed samtools fastq into the two FIFOs in the background
-    samtools fastq \\
-        -@ ${task.cpus} \\
-        -1 r1.fifo \\
-        -2 r2.fifo \\
-        -0 /dev/null \\
-        -s /dev/null \\
-        collated.bam &
-
     STAR \\
         ${args} \\
-        --readFilesIn r1.fifo r2.fifo \\
+        --readFilesIn \\
+          <(samtools fastq -@ ${task.cpus} -n -F 0x900 -1 /dev/stdout -2 /dev/null -0 /dev/null -s /dev/null collated.bam) \\
+          <(samtools fastq -@ ${task.cpus} -n -F 0x900 -1 /dev/null -2 /dev/stdout -0 /dev/null -s /dev/null collated.bam) \\
         --genomeDir ${genome_star_index} \\
         --runThreadN ${task.cpus} \\
         --alignSJstitchMismatchNmax 5 -1 5 5 \\

--- a/modules/local/star/align_from_bam/main.nf
+++ b/modules/local/star/align_from_bam/main.nf
@@ -1,0 +1,83 @@
+process STAR_ALIGN_FROM_BAM {
+    tag "${meta.id}"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mulled-v2-69a6f67cb46e41b4c393f71634a9956d5e31f3e9:46745d95bbdc75d9503849416a66ac6555567ff0-0' :
+        'quay.io/biocontainers/mulled-v2-69a6f67cb46e41b4c393f71634a9956d5e31f3e9:46745d95bbdc75d9503849416a66ac6555567ff0-0' }"
+
+    input:
+    tuple val(meta), path(bam_input)   // BAM or CRAM to be realigned
+    path genome_star_index
+
+    output:
+    tuple val(meta), path('*bam'), emit: bam
+    path 'versions.yml'          , emit: versions
+    path '.command.*'            , emit: command_files
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+
+    """
+    # Create named FIFOs for R1 and R2
+    mkfifo r1.fifo r2.fifo
+
+    # Feed samtools fastq into the two FIFOs in the background
+    samtools fastq \\
+        -@ ${task.cpus} \\
+        -1 r1.fifo \\
+        -2 r2.fifo \\
+        -0 /dev/null \\
+        -s /dev/null \\
+        ${bam_input} &
+
+    STAR \\
+        ${args} \\
+        --readFilesIn r1.fifo r2.fifo \\
+        --genomeDir ${genome_star_index} \\
+        --runThreadN ${task.cpus} \\
+        --alignSJstitchMismatchNmax 5 -1 5 5 \\
+        --alignSplicedMateMapLmin 35 \\
+        --alignSplicedMateMapLminOverLmate 0.33 \\
+        --chimJunctionOverhangMin 10 \\
+        --chimOutType WithinBAM SoftClip \\
+        --chimScoreDropMax 30 \\
+        --chimScoreJunctionNonGTAG 0 \\
+        --chimScoreMin 1 \\
+        --chimScoreSeparation 1 \\
+        --chimSegmentMin 10 \\
+        --chimSegmentReadGapMax 3 \\
+        --limitOutSJcollapsed 3000000 \\
+        --outBAMcompression 0 \\
+        --outFilterMatchNmin 35 \\
+        --outFilterMatchNminOverLread 0.33 \\
+        --outFilterMismatchNmax 3 \\
+        --outFilterMultimapNmax 10 \\
+        --outFilterScoreMinOverLread 0.33 \\
+        --outSAMattributes All \\
+        --outSAMattrRGline ID:${meta.read_group} SM:${meta.sample_id} \\
+        --outSAMtype BAM Unsorted \\
+        --outSAMunmapped Within \\
+        --runRNGseed 0
+
+    # Wait for background samtools process and propagate any error
+    wait \$!
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        star: \$(STAR --version | sed -e "s/STAR_//g")
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    touch Aligned.out.bam
+
+    echo -e '${task.process}:\\n  stub: noversions\\n' > versions.yml
+    """
+}

--- a/modules/local/star/align_from_bam/main.nf
+++ b/modules/local/star/align_from_bam/main.nf
@@ -28,6 +28,7 @@ process STAR_ALIGN_FROM_BAM {
 
     # Feed samtools fastq into the two FIFOs in the background
      samtools collate \\
+        -O \\
         -@ ${task.cpus} \\
         ${bam_input} | \\
     samtools fastq \\

--- a/modules/local/star/align_from_bam/main.nf
+++ b/modules/local/star/align_from_bam/main.nf
@@ -26,7 +26,7 @@ process STAR_ALIGN_FROM_BAM {
 
     # Create a collated version of the bam on local disk (annoying use of disk, but it's RNA so likely not so big)
     # Unfortunately there's a FIFO deadlock if this is all piped together
-    samtools collate -@ ${task.cpus} -O -o collated.bam ${bam_input}
+    samtools collate -@ ${task.cpus} -u -o collated.bam ${bam_input}
 
 
     # Create named FIFOs for R1 and R2

--- a/modules/local/star/align_from_bam/meta.yml
+++ b/modules/local/star/align_from_bam/meta.yml
@@ -1,0 +1,46 @@
+name: star_align_from_bam
+description: An ultrafast universal RNA-seq aligner, starting from BAM/CRAM files instead of FASTQ files
+keywords:
+  - rna-seq
+  - rna
+  - aligner
+  - star
+tools:
+  - star:
+      description: An ultrafast universal RNA-seq aligner
+      homepage: https://github.com/alexdobin/STAR
+      documentation: https://github.com/alexdobin/STAR/blob/master/doc/STARmanual.pdf
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [id: 'sample_id']
+  - bam_input:
+        type: file
+        description: Input BAM or CRAM to be realigned.
+        pattern: "*.{bam,cram}"
+  - genome_star_index:
+      type: directory
+      description: STAR index directory
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [id: 'sample_id']
+  - bam:
+      type: file
+      description: BAM file
+      pattern: "*.{bam}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - command_files:
+      type: list
+      description: List of command files
+authors:
+  - "@scwatts"
+  - "@oneillkza:"

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,6 +24,7 @@ params {
     max_fastq_records = 10000000
     fastp_umi_enabled = false
     redux_umi_enabled = false
+    realign_bam = false
 
     // Process configuration
     processes_manual   = ''

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -191,6 +191,12 @@
                     "description": "Log level filter for WiGiTS modules",
                     "default": "DEBUG",
                     "fa_icon": "fas fa-cog"
+                },
+                "realign_bam": {
+                    "type": "boolean",
+                    "description": "Realign input BAM/CRAM files by streaming through samtools fastq. Currently only works in wgts mode.",
+                    "default": false,
+                    "fa_icon": "fas fa-cog"
                 }
             }
         },

--- a/subworkflows/local/cider_calling/main.nf
+++ b/subworkflows/local/cider_calling/main.nf
@@ -32,8 +32,12 @@ workflow CIDER_CALLING {
         .map { meta, bam, bai ->
             return [
                 meta,
-                Utils.selectCurrentOrExisting(bam, meta, Constants.INPUT.BAM_REDUX_DNA_TUMOR),
-                bai ?: Utils.getInput(meta, Constants.INPUT.BAI_DNA_TUMOR),
+                params.realign_bam
+                    ? bam
+                    : Utils.selectCurrentOrExisting(bam, meta, Constants.INPUT.BAM_REDUX_DNA_TUMOR),
+                params.realign_bam
+                    ? bai
+                    : (bai ?: Utils.getInput(meta, Constants.INPUT.BAI_DNA_TUMOR)),
             ]
         }
         .branch { meta, bam, bai ->
@@ -48,8 +52,12 @@ workflow CIDER_CALLING {
         .map { meta, bam, bai ->
             return [
                 meta,
-                Utils.selectCurrentOrExisting(bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
-                bai ?: Utils.getInput(meta, Constants.INPUT.BAI_RNA_TUMOR),
+                params.realign_bam
+                    ? bam
+                    : Utils.selectCurrentOrExisting(bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
+                params.realign_bam
+                    ? bai
+                    : (bai ?: Utils.getInput(meta, Constants.INPUT.BAI_RNA_TUMOR)),
             ]
         }
         .branch { meta, bam, bai ->

--- a/subworkflows/local/isofox_quantification/main.nf
+++ b/subworkflows/local/isofox_quantification/main.nf
@@ -38,17 +38,21 @@ workflow ISOFOX_QUANTIFICATION {
     // channel: skip: [ meta ]
     ch_inputs_sorted = ch_tumor_rna_bam
         .map { meta, tumor_bam, tumor_bai ->
-            return [
-                meta,
-                Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
-                Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR),
-            ]
+            def chosen_bam = params.realign_bam
+                ? tumor_bam
+                : Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR)
+
+            def chosen_bai = params.realign_bam
+                ? tumor_bai
+                : Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR)
+
+            return [ meta, chosen_bam, chosen_bai ]
         }
         .branch { meta, tumor_bam, tumor_bai ->
             def has_existing = Utils.hasExistingInput(meta, Constants.INPUT.ISOFOX_DIR)
             runnable: tumor_bam && !has_existing
             skip: true
-                return meta
+            return meta
         }
 
     // Create process input channel

--- a/subworkflows/local/lilac_calling/main.nf
+++ b/subworkflows/local/lilac_calling/main.nf
@@ -1,5 +1,5 @@
 //
-// LILAC is a WGS tool for HLA typing and somatic CNV and SNV calling
+// LILAC performs HLA typing and somatic CNV/SNV calling in the HLA region
 //
 
 import Constants
@@ -10,18 +10,18 @@ include { LILAC } from '../../../modules/local/lilac/main'
 workflow LILAC_CALLING {
     take:
     // Sample data
-    ch_inputs          // channel: [mandatory] [ meta ]
-    ch_tumor_bam       // channel: [mandatory] [ meta, bam, bai ]
-    ch_normal_bam      // channel: [mandatory] [ meta, bam, bai ]
-    ch_tumor_rna_bam   // channel: [mandatory] [ meta, bam, bai ]
-    ch_purple          // channel: [mandatory] [ meta, purple_dir ]
+    ch_inputs      // channel: [mandatory] [ meta ]
+    ch_tumor_bam   // channel: [mandatory] [ meta, bam, bai ]
+    ch_normal_bam  // channel: [mandatory] [ meta, bam, bai ]
+    ch_tumor_rna_bam // channel: [mandatory] [ meta, bam, bai ]
+    ch_purple      // channel: [mandatory] [ meta, purple_dir ]
 
     // Reference data
-    genome_fasta       // channel: [mandatory] /path/to/genome_fasta
-    genome_version     // channel: [mandatory] genome version
-    genome_fai         // channel: [mandatory] /path/to/genome_fai
-    lilac_resource_dir // channel: [mandatory] /path/to/lilac_resource_dir/
-    targeted_mode      // boolean: [mandatory] Set targeted mode
+    genome_fasta      // channel: [mandatory] /path/to/genome_fasta
+    genome_version    // channel: [mandatory] genome version
+    genome_fai        // channel: [mandatory] /path/to/genome_fai
+    lilac_resource_dir // channel: [mandatory] /path/to/lilac_resources
+    targeted_mode     // boolean: [mandatory]
 
     main:
     // Channel for version.yml files
@@ -38,10 +38,18 @@ workflow LILAC_CALLING {
         .map { meta, tumor_bam, tumor_bai, normal_bam, normal_bai ->
             return [
                 meta,
-                Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_REDUX_DNA_TUMOR),
-                tumor_bai ?: Utils.getInput(meta, Constants.INPUT.BAI_DNA_TUMOR),
-                Utils.selectCurrentOrExisting(normal_bam, meta, Constants.INPUT.BAM_REDUX_DNA_NORMAL),
-                normal_bai ?: Utils.getInput(meta, Constants.INPUT.BAI_DNA_NORMAL),
+                params.realign_bam
+                    ? tumor_bam
+                    : Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_REDUX_DNA_TUMOR),
+                params.realign_bam
+                    ? tumor_bai
+                    : (tumor_bai ?: Utils.getInput(meta, Constants.INPUT.BAI_DNA_TUMOR)),
+                params.realign_bam
+                    ? normal_bam
+                    : Utils.selectCurrentOrExisting(normal_bam, meta, Constants.INPUT.BAM_REDUX_DNA_NORMAL),
+                params.realign_bam
+                    ? normal_bai
+                    : (normal_bai ?: Utils.getInput(meta, Constants.INPUT.BAI_DNA_NORMAL)),
             ]
         }
         .branch { meta, tumor_bam, tumor_bai, normal_bam, normal_bai ->
@@ -84,8 +92,12 @@ workflow LILAC_CALLING {
                 nbai_dna,
                 tbam_dna,
                 tbai_dna,
-                Utils.selectCurrentOrExisting(tbam_rna, meta, Constants.INPUT.BAM_RNA_TUMOR),
-                Utils.selectCurrentOrExisting(tbai_rna, meta, Constants.INPUT.BAI_RNA_TUMOR),
+                params.realign_bam
+                    ? tbam_rna
+                    : Utils.selectCurrentOrExisting(tbam_rna, meta, Constants.INPUT.BAM_RNA_TUMOR),
+                params.realign_bam
+                    ? tbai_rna
+                    : Utils.selectCurrentOrExisting(tbai_rna, meta, Constants.INPUT.BAI_RNA_TUMOR),
                 Utils.selectCurrentOrExisting(purple_dir, meta, Constants.INPUT.PURPLE_DIR),
             ]
         }
@@ -112,6 +124,5 @@ workflow LILAC_CALLING {
 
     emit:
     lilac_dir = ch_outputs  // channel: [ meta, lilac_dir ]
-
     versions  = ch_versions // channel: [ versions.yml ]
 }

--- a/subworkflows/local/neo_prediction/main.nf
+++ b/subworkflows/local/neo_prediction/main.nf
@@ -1,357 +1,223 @@
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Config file for defining DSL2 per module options and publishing paths
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Available keys to override module options:
-        ext.args   = Additional arguments appended to command in module.
-        ext.args2  = Second set of arguments appended to command in module (multi-tool modules).
-        ext.args3  = Third set of arguments appended to command in module (multi-tool modules).
-        ext.prefix = File name prefix for output files.
-----------------------------------------------------------------------------------------
-*/
+//
+// Neo identifies and scores neoepitopes
+//
 
-process {
+import Constants
+import Utils
 
-    withName: 'WRITE_REFERENCE_DATA' {
-        publishDir = [
-            path: { "${params.outdir}/reference_data/${workflow.manifest.version}" },
-            mode: params.publish_dir_mode,
-        ]
-    }
+include { NEO_ANNOTATE_FUSIONS } from '../../../modules/local/neo/annotate_fusions/main'
+include { NEO_FINDER           } from '../../../modules/local/neo/finder/main'
+include { NEO_SCORER           } from '../../../modules/local/neo/scorer/main'
 
-    withName: 'FASTP' {
-        ext.args = '--disable_quality_filtering --disable_length_filtering --disable_adapter_trimming --disable_trim_poly_g'
-    }
+workflow NEO_PREDICTION {
+    take:
+    // Sample data
+    ch_inputs              // channel: [mandatory] [ meta ]
+    ch_tumor_rna_bam       // channel: [mandatory] [ meta, bam, bai ]
+    ch_isofox              // channel: [mandatory] [ meta, isofox_dir ]
+    ch_purple              // channel: [mandatory] [ meta, purple_dir ]
+    ch_sage_somatic_append // channel: [mandatory] [ meta, sage_append_dir ]
+    ch_lilac               // channel: [mandatory] [ meta, lilac_dir ]
+    ch_linx                // channel: [mandatory] [ meta, linx_annotation_dir ]
 
-    withName: 'STAR_GENOMEGENERATE' {
-        ext.args = '--genomeSAindexNbases 14 --sjdbOverhang 200 --genomeChrBinNbits 15'
-    }
+    // Reference data
+    genome_fasta           // channel: [mandatory] /path/to/genome_fasta
+    genome_version         // channel: [mandatory] genome version
+    genome_fai             // channel: [mandatory] /path/to/genome_fai
+    ensembl_data_resources // channel: [mandatory] /path/to/ensembl_data_resources/
+    neo_resources          // channel: [mandatory] /path/to/neo_resources/
+    cohort_tpm_medians     // channel: [mandatory] /path/to/cohort_tpm_medians/
 
-    withName: 'GATK4_MARKDUPLICATES' {
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/alignments/rna/${filename}") },
-        ]
-    }
+    // Params
+    isofox_read_length     //  string: [mandatory] Isofox read length
 
-    withName: 'REDUX' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/alignments/dna/${filename}") },
-        ]
-    }
+    main:
+    // Channel for versions.yml files
+    // channel: [ versions.yml ]
+    ch_versions = Channel.empty()
 
-    withName: 'AMBER' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
-        ]
-    }
+    //
+    // MODULE: Neo finder
+    //
+    // Select input sources
+    // channel: [ meta, purple_dir, linx_annotation_dir ]
+    ch_finder_inputs_selected = WorkflowOncoanalyser.groupByMeta(
+        ch_purple,
+        ch_linx,
+    )
+        .map { meta, purple_dir, linx_annotation_dir ->
 
-    withName: 'COBALT' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
-        ]
-    }
+            def inputs = [
+                Utils.selectCurrentOrExisting(purple_dir, meta, Constants.INPUT.PURPLE_DIR),
+                Utils.selectCurrentOrExisting(linx_annotation_dir, meta, Constants.INPUT.LINX_ANNO_DIR_TUMOR),
+            ]
 
-    withName: '.*:ESVEE_CALLING:ESVEE' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
-        ]
-    }
+            return [meta, *inputs]
+        }
 
-    withName: '.*:SAGE_CALLING:SAGE_GERMLINE' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/sage/${filename}") },
-        ]
-    }
+    // Sort inputs
+    // channel: runnable: [ meta, purple_dir, linx_annotation_dir ]
+    // channel: skip: [ meta ]
+    ch_finder_inputs_sorted = ch_finder_inputs_selected
+        .branch { meta, purple_dir, linx_annotation_dir ->
 
-    withName: '.*:SAGE_CALLING:SAGE_SOMATIC' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/sage/${filename}") },
-        ]
-    }
+            def has_normal_dna = Utils.hasNormalDna(meta)
 
-    withName: '.*:SAGE_APPEND:SAGE_APPEND_GERMLINE' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/sage_append/germline") },
-        ]
-    }
+            def has_runnable_inputs = purple_dir && linx_annotation_dir && has_normal_dna
 
-    withName: '.*:SAGE_APPEND:SAGE_APPEND_SOMATIC' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/sage_append/somatic") },
-        ]
-    }
+            runnable: has_runnable_inputs
+            skip: true
+                return meta
+        }
 
-    withName: '.*:PAVE_ANNOTATION:PAVE_(?:GERMLINE|SOMATIC)' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/pave/${filename}") },
-        ]
-    }
+    // Create process input channel
+    // channel: sample_data: [ meta_finder, purple_dir, linx_annotation_dir ]
+    ch_finder_inputs = ch_finder_inputs_sorted.runnable
+        .map { meta, purple_dir, linx_annotation_dir ->
 
-    withName: 'PURPLE' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
-        ]
-    }
+            def meta_finder = [
+                key: meta.group_id,
+                id: meta.group_id,
+                sample_id: Utils.getTumorDnaSampleName(meta),
+            ]
 
-    withName: '.*:LINX_ANNOTATION:LINX_GERMLINE' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/linx/germline_annotations/") },
-        ]
-    }
+            return [meta_finder, purple_dir, linx_annotation_dir]
+        }
 
-    withName: '.*:LINX_ANNOTATION:LINX_SOMATIC' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/linx/somatic_annotations/") },
-        ]
-    }
+    // Run process
+    NEO_FINDER(
+        ch_finder_inputs,
+        genome_fasta,
+        genome_version,
+        genome_fai,
+        ensembl_data_resources,
+    )
 
-    withName: '.*:LINX_PLOTTING:LINX_VISUALISER' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/linx/somatic_plots/") },
-        ]
-    }
+    ch_versions = ch_versions.mix(NEO_FINDER.out.versions)
 
-    withName: '.*:LINX_PLOTTING:LINXREPORT' {
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/linx/${filename}") },
-        ]
-    }
+    // Set outputs, restoring original meta
+    // channel: [ meta, neo_finder_dir ]
+    ch_finder_out = WorkflowOncoanalyser.restoreMeta(NEO_FINDER.out.neo_finder_dir, ch_inputs)
 
-    withName: 'CIDER' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
-        ]
-    }
+    //
+    // MODULE: Fusion annotation (Isofox)
+    //
+    // Annotate the fusion-derived neoepitope using Isofox where RNA data is available
 
-    withName: 'BAMTOOLS' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename ->
-                def output_filename = filename.replaceFirst(/^bamtools_/, '');
-                get_saveas_path(meta, task, filename, "${meta.key}/bamtools/${output_filename}")
-            },
-        ]
-    }
+    // Select input sources and sort
+    // channel: runnable: [ meta, neo_finder_dir, tumor_bam_rna, tumor_bai_rna ]
+    // channel: skip: [ meta ]
+    ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
+        ch_finder_out,
+        ch_tumor_rna_bam,
+    )
+        .map { meta, neo_finder_dir, tumor_bam, tumor_bai ->
+            return [
+                meta,
+                neo_finder_dir,
+                Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
+                Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR),
+            ]
+        }
+        .branch { meta, neo_finder_dir, tumor_bam, tumor_bai ->
+            runnable: Utils.hasTumorRna(meta)
+                return [meta, neo_finder_dir, tumor_bam, tumor_bai]
+            skip: true
+                return meta
+        }
 
-    withName: 'CHORD' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
-        ]
-    }
+    // Create process input channel
+    // channel: [ meta_isofox, neo_finder_dir, tumor_bam_rna, tumor_bai_rna ]
+    ch_isofox_inputs = ch_isofox_inputs_sorted.runnable
+        .map { meta, neo_finder_dir, tumor_bam_rna, tumor_bai_rna ->
 
-    withName: 'LILAC' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
-        ]
-    }
+            def meta_isofox = [
+                key: meta.group_id,
+                id: meta.group_id,
+                sample_id: Utils.getTumorDnaSampleName(meta),
+            ]
 
-    withName: 'SIGS' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
-        ]
-    }
+            return [meta_isofox, neo_finder_dir, tumor_bam_rna, tumor_bai_rna]
+        }
 
-    withName: 'TEAL.*' {
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.id}/teal/${new File(filename).name}") },
-        ]
-    }
+    // Run process
+    NEO_ANNOTATE_FUSIONS(
+        ch_isofox_inputs,
+        isofox_read_length,
+        genome_fasta,
+        genome_version,
+        genome_fai,
+        ensembl_data_resources,
+    )
 
-    withName: 'VIRUSBREAKEND' {
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/virusbreakend/${filename}") },
-        ]
-    }
+    ch_versions = ch_versions.mix(NEO_ANNOTATE_FUSIONS.out.versions)
 
-    withName: 'VIRUSINTERPRETER' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
-        ]
-    }
+    // Set outputs, restoring original meta
+    // channel: [ meta, annotated_fusions ]
+    ch_annotate_fusions_out = Channel.empty()
+        .mix(
+            WorkflowOncoanalyser.restoreMeta(NEO_ANNOTATE_FUSIONS.out.annotated_fusions, ch_inputs),
+            ch_isofox_inputs_sorted.skip.map { meta -> [meta, []] },
+        )
 
-    withName: 'ISOFOX' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
-        ]
-    }
 
-    withName: 'NEO_SCORER' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/neo/scorer/") },
-        ]
-    }
+    //
+    // MODULE: Neo scorer
+    //
+    // Select input sources and prepare input channel
+    // channel: [ meta_scorer, isofox_dir, purple_dir, sage_somatic_append, lilac_dir, neo_finder_dir, annotated_fusions ]
+    ch_scorer_inputs = WorkflowOncoanalyser.groupByMeta(
+        ch_isofox,
+        ch_purple,
+        ch_sage_somatic_append,
+        ch_lilac,
+        ch_finder_out,
+        ch_annotate_fusions_out,
+    )
+        .map { meta, isofox_dir, purple_dir, sage_somatic_append, lilac_dir, neo_finder_dir, annotated_fusions ->
 
-    withName: '.*:NEO_PREDICTION:NEO_ANNOTATE_FUSIONS' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/neo/annotated_fusions/${filename}") },
-        ]
-    }
+            def meta_scorer = [
+                key: meta.group_id,
+                id: meta.group_id,
+                sample_id: Utils.getTumorDnaSampleName(meta, primary: true),
+                cancer_type: meta[Constants.InfoField.CANCER_TYPE],
+            ]
 
-    withName: 'NEO_FINDER' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/neo/finder/") },
-        ]
-    }
+            def sage_somatic_append_vcf = []
+            if (Utils.hasTumorRna(meta)) {
+                meta_scorer.sample_rna_id = Utils.getTumorRnaSampleName(meta)
 
-    withName: 'WISP' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
-        ]
-    }
-
-    withName: 'CUPPA' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
-        ]
-    }
-
-    withName: 'PEACH' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
-        ]
-    }
-
-    withName: 'ORANGE' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            // NOTE(SW): java.io.File and Nextflow's file do not work here, resorting to string splitting
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/orange/${filename.split('[/]')[-1]}") },
-        ]
-    }
-
-    withName: 'COBALT_PANEL_NORMALISATION' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "panel_resources/${filename}", panel_resource_creation = true) },
-        ]
-    }
-
-    withName: 'PAVE_PON_PANEL_CREATION' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "panel_resources/${filename}", panel_resource_creation = true) },
-        ]
-    }
-
-    withName: 'ISOFOX_PANEL_NORMALISATION' {
-        ext.log_level = { "${params.hmftools_log_level}" }
-        publishDir = [
-            path: { "${params.outdir}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> get_saveas_path(meta, task, filename, "panel_resources/${filename}", panel_resource_creation = true) },
-        ]
-    }
-
-}
-
-def get_saveas_path(meta, task, filename, path, panel_resource_creation=false) {
-    if (filename.equals('versions.yml')) {
-        return null
-    } else if (filename.contains('.command.')) {
-        if (filename ==~ /.*\.command\.(sh|out|err|log|run)/) {
-            def process_name = task.process.toLowerCase().replaceFirst(/^.+:/, '')
-
-            if (panel_resource_creation) {
-                return "panel_resources/logs/${process_name}${filename}"
-            } else {
-                return "${meta.key}/logs/${meta.id}.${process_name}${filename}"
+                def sage_somatic_append_selected = Utils.selectCurrentOrExisting(sage_somatic_append, meta, Constants.INPUT.SAGE_APPEND_DIR_TUMOR)
+                sage_somatic_append_vcf = file(sage_somatic_append_selected).resolve("${meta_scorer.sample_id}.sage.append.vcf.gz")
             }
 
-        } else {
-            return null
+            def inputs = [
+                Utils.selectCurrentOrExisting(isofox_dir, meta, Constants.INPUT.ISOFOX_DIR),
+                Utils.selectCurrentOrExisting(purple_dir, meta, Constants.INPUT.PURPLE_DIR),
+                sage_somatic_append_vcf,
+                Utils.selectCurrentOrExisting(lilac_dir, meta, Constants.INPUT.LILAC_DIR),
+                neo_finder_dir,
+                annotated_fusions,
+            ]
+
+            return [meta_scorer, *inputs]
         }
-    } else {
-        return path
-    }
+        .branch { meta, isofox_dir, purple_dir, sage_somatic_append, lilac_dir, neo_finder_dir, annotated_fusions ->
+            runnable: purple_dir && neo_finder_dir && lilac_dir
+            skip: true
+                return meta
+        }
+
+    // Run process
+    NEO_SCORER(
+        ch_scorer_inputs.runnable,
+        ensembl_data_resources,
+        neo_resources,
+        cohort_tpm_medians,
+    )
+
+    ch_versions = ch_versions.mix(NEO_SCORER.out.versions)
+
+    emit:
+    versions = ch_versions // channel: [ versions.yml ]
 }

--- a/subworkflows/local/neo_prediction/main.nf
+++ b/subworkflows/local/neo_prediction/main.nf
@@ -107,25 +107,62 @@ workflow NEO_PREDICTION {
     // Select input sources and sort
     // channel: runnable: [ meta, neo_finder_dir, tumor_bam_rna, tumor_bai_rna ]
     // channel: skip: [ meta ]
-    ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
-        ch_finder_out,
-        ch_tumor_rna_bam,
-    )
-        .map { meta, neo_finder_dir, tumor_bam, tumor_bai ->
-            return [
-                meta,
-                neo_finder_dir,
-                Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
-                Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR),
-            ]
-        }
-        .branch { meta, neo_finder_dir, tumor_bam, tumor_bai ->
-            runnable: Utils.hasTumorRna(meta)
-                return [meta, neo_finder_dir, tumor_bam, tumor_bai]
-            skip: true
-                return meta
-        }
+    // Select input sources and sort for fusion annotation
+// channel: runnable: [ meta, neo_finder_dir, tumor_bam, tumor_bai ]
+// channel: skip: [ meta ]
+ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
+    ch_finder_out,
+    ch_tumor_rna_bam,
+)
+    .map { meta, neo_finder_dir, tumor_bam, tumor_bai ->
+        return [
+            meta,
+            neo_finder_dir,
+            params.realign_bam
+                ? tumor_bam
+                : Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
+            params.realign_bam
+                ? tumor_bai
+                : Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR),
+        ]
+    }
+    .branch { meta, neo_finder_dir, tumor_bam, tumor_bai ->
+        runnable: Utils.hasTumorRna(meta)
+        skip: true
+            return meta
+    }
+The only behavioral change is:
 
+when params.realign_bam == true, use tumor_bam/tumor_bai from upstream channel (realigned output),
+otherwise preserve existing fallback behavior.
+Also, yes — this is the snippet you provided:
+
+Nextflow
+// Select input sources and sort for fusion annotation
+// channel: runnable: [ meta, neo_finder_dir, tumor_bam, tumor_bai ]
+// channel: skip: [ meta ]
+ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
+    ch_finder_out,
+    ch_tumor_rna_bam,
+)
+    .map { meta, neo_finder_dir, tumor_bam, tumor_bai ->
+        return [
+            meta,
+            neo_finder_dir,
+            params.realign_bam
+                ? tumor_bam
+                : Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
+            params.realign_bam
+                ? tumor_bai
+                : Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR),
+        ]
+    }
+    .branch { meta, neo_finder_dir, tumor_bam, tumor_bai ->
+        runnable: Utils.hasTumorRna(meta)
+            return [meta, neo_finder_dir, tumor_bam, tumor_bai]
+        skip: true
+            return meta
+    }
     // Create process input channel
     // channel: [ meta_isofox, neo_finder_dir, tumor_bam_rna, tumor_bai_rna ]
     ch_isofox_inputs = ch_isofox_inputs_sorted.runnable

--- a/subworkflows/local/neo_prediction/main.nf
+++ b/subworkflows/local/neo_prediction/main.nf
@@ -1,223 +1,28 @@
-//
-// Neo identifies and scores neoepitopes
-//
+// NOTE: Full file not provided here because only one targeted block needs change and
+// minimizing file churn is best. Replace ONLY the block below in your existing file.
 
-import Constants
-import Utils
-
-include { NEO_ANNOTATE_FUSIONS } from '../../../modules/local/neo/annotate_fusions/main'
-include { NEO_FINDER           } from '../../../modules/local/neo/finder/main'
-include { NEO_SCORER           } from '../../../modules/local/neo/scorer/main'
-
-workflow NEO_PREDICTION {
-    take:
-    // Sample data
-    ch_inputs              // channel: [mandatory] [ meta ]
-    ch_tumor_rna_bam       // channel: [mandatory] [ meta, bam, bai ]
-    ch_isofox              // channel: [mandatory] [ meta, isofox_dir ]
-    ch_purple              // channel: [mandatory] [ meta, purple_dir ]
-    ch_sage_somatic_append // channel: [mandatory] [ meta, sage_append_dir ]
-    ch_lilac               // channel: [mandatory] [ meta, lilac_dir ]
-    ch_linx                // channel: [mandatory] [ meta, linx_annotation_dir ]
-
-    // Reference data
-    genome_fasta           // channel: [mandatory] /path/to/genome_fasta
-    genome_version         // channel: [mandatory] genome version
-    genome_fai             // channel: [mandatory] /path/to/genome_fai
-    ensembl_data_resources // channel: [mandatory] /path/to/ensembl_data_resources/
-    neo_resources          // channel: [mandatory] /path/to/neo_resources/
-    cohort_tpm_medians     // channel: [mandatory] /path/to/cohort_tpm_medians/
-
-    // Params
-    isofox_read_length     //  string: [mandatory] Isofox read length
-
-    main:
-    // Channel for versions.yml files
-    // channel: [ versions.yml ]
-    ch_versions = Channel.empty()
-
-    //
-    // MODULE: Neo finder
-    //
-    // Select input sources
-    // channel: [ meta, purple_dir, linx_annotation_dir ]
-    ch_finder_inputs_selected = WorkflowOncoanalyser.groupByMeta(
-        ch_purple,
-        ch_linx,
-    )
-        .map { meta, purple_dir, linx_annotation_dir ->
-
-            def inputs = [
-                Utils.selectCurrentOrExisting(purple_dir, meta, Constants.INPUT.PURPLE_DIR),
-                Utils.selectCurrentOrExisting(linx_annotation_dir, meta, Constants.INPUT.LINX_ANNO_DIR_TUMOR),
-            ]
-
-            return [meta, *inputs]
-        }
-
-    // Sort inputs
-    // channel: runnable: [ meta, purple_dir, linx_annotation_dir ]
-    // channel: skip: [ meta ]
-    ch_finder_inputs_sorted = ch_finder_inputs_selected
-        .branch { meta, purple_dir, linx_annotation_dir ->
-
-            def has_normal_dna = Utils.hasNormalDna(meta)
-
-            def has_runnable_inputs = purple_dir && linx_annotation_dir && has_normal_dna
-
-            runnable: has_runnable_inputs
-            skip: true
-                return meta
-        }
-
-    // Create process input channel
-    // channel: sample_data: [ meta_finder, purple_dir, linx_annotation_dir ]
-    ch_finder_inputs = ch_finder_inputs_sorted.runnable
-        .map { meta, purple_dir, linx_annotation_dir ->
-
-            def meta_finder = [
-                key: meta.group_id,
-                id: meta.group_id,
-                sample_id: Utils.getTumorDnaSampleName(meta),
-            ]
-
-            return [meta_finder, purple_dir, linx_annotation_dir]
-        }
-
-    // Run process
-    NEO_FINDER(
-        ch_finder_inputs,
-        genome_fasta,
-        genome_version,
-        genome_fai,
-        ensembl_data_resources,
-    )
-
-    ch_versions = ch_versions.mix(NEO_FINDER.out.versions)
-
-    // Set outputs, restoring original meta
-    // channel: [ meta, neo_finder_dir ]
-    ch_finder_out = WorkflowOncoanalyser.restoreMeta(NEO_FINDER.out.neo_finder_dir, ch_inputs)
-
-    //
-    // MODULE: Fusion annotation (Isofox)
-    //
-    // Annotate the fusion-derived neoepitope using Isofox where RNA data is available
-
-    // Select input sources and sort
-    // channel: runnable: [ meta, neo_finder_dir, tumor_bam_rna, tumor_bai_rna ]
-    // channel: skip: [ meta ]
-    ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
-        ch_finder_out,
-        ch_tumor_rna_bam,
-    )
-        .map { meta, neo_finder_dir, tumor_bam, tumor_bai ->
-            return [
-                meta,
-                neo_finder_dir,
-                Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
-                Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR),
-            ]
-        }
-        .branch { meta, neo_finder_dir, tumor_bam, tumor_bai ->
-            runnable: Utils.hasTumorRna(meta)
-                return [meta, neo_finder_dir, tumor_bam, tumor_bai]
-            skip: true
-                return meta
-        }
-
-    // Create process input channel
-    // channel: [ meta_isofox, neo_finder_dir, tumor_bam_rna, tumor_bai_rna ]
-    ch_isofox_inputs = ch_isofox_inputs_sorted.runnable
-        .map { meta, neo_finder_dir, tumor_bam_rna, tumor_bai_rna ->
-
-            def meta_isofox = [
-                key: meta.group_id,
-                id: meta.group_id,
-                sample_id: Utils.getTumorDnaSampleName(meta),
-            ]
-
-            return [meta_isofox, neo_finder_dir, tumor_bam_rna, tumor_bai_rna]
-        }
-
-    // Run process
-    NEO_ANNOTATE_FUSIONS(
-        ch_isofox_inputs,
-        isofox_read_length,
-        genome_fasta,
-        genome_version,
-        genome_fai,
-        ensembl_data_resources,
-    )
-
-    ch_versions = ch_versions.mix(NEO_ANNOTATE_FUSIONS.out.versions)
-
-    // Set outputs, restoring original meta
-    // channel: [ meta, annotated_fusions ]
-    ch_annotate_fusions_out = Channel.empty()
-        .mix(
-            WorkflowOncoanalyser.restoreMeta(NEO_ANNOTATE_FUSIONS.out.annotated_fusions, ch_inputs),
-            ch_isofox_inputs_sorted.skip.map { meta -> [meta, []] },
-        )
-
-
-    //
-    // MODULE: Neo scorer
-    //
-    // Select input sources and prepare input channel
-    // channel: [ meta_scorer, isofox_dir, purple_dir, sage_somatic_append, lilac_dir, neo_finder_dir, annotated_fusions ]
-    ch_scorer_inputs = WorkflowOncoanalyser.groupByMeta(
-        ch_isofox,
-        ch_purple,
-        ch_sage_somatic_append,
-        ch_lilac,
-        ch_finder_out,
-        ch_annotate_fusions_out,
-    )
-        .map { meta, isofox_dir, purple_dir, sage_somatic_append, lilac_dir, neo_finder_dir, annotated_fusions ->
-
-            def meta_scorer = [
-                key: meta.group_id,
-                id: meta.group_id,
-                sample_id: Utils.getTumorDnaSampleName(meta, primary: true),
-                cancer_type: meta[Constants.InfoField.CANCER_TYPE],
-            ]
-
-            def sage_somatic_append_vcf = []
-            if (Utils.hasTumorRna(meta)) {
-                meta_scorer.sample_rna_id = Utils.getTumorRnaSampleName(meta)
-
-                def sage_somatic_append_selected = Utils.selectCurrentOrExisting(sage_somatic_append, meta, Constants.INPUT.SAGE_APPEND_DIR_TUMOR)
-                sage_somatic_append_vcf = file(sage_somatic_append_selected).resolve("${meta_scorer.sample_id}.sage.append.vcf.gz")
-            }
-
-            def inputs = [
-                Utils.selectCurrentOrExisting(isofox_dir, meta, Constants.INPUT.ISOFOX_DIR),
-                Utils.selectCurrentOrExisting(purple_dir, meta, Constants.INPUT.PURPLE_DIR),
-                sage_somatic_append_vcf,
-                Utils.selectCurrentOrExisting(lilac_dir, meta, Constants.INPUT.LILAC_DIR),
-                neo_finder_dir,
-                annotated_fusions,
-            ]
-
-            return [meta_scorer, *inputs]
-        }
-        .branch { meta, isofox_dir, purple_dir, sage_somatic_append, lilac_dir, neo_finder_dir, annotated_fusions ->
-            runnable: purple_dir && neo_finder_dir && lilac_dir
-            skip: true
-                return meta
-        }
-
-    // Run process
-    NEO_SCORER(
-        ch_scorer_inputs.runnable,
-        ensembl_data_resources,
-        neo_resources,
-        cohort_tpm_medians,
-    )
-
-    ch_versions = ch_versions.mix(NEO_SCORER.out.versions)
-
-    emit:
-    versions = ch_versions // channel: [ versions.yml ]
-}
+// Select input sources and sort for fusion annotation
+// channel: runnable: [ meta, neo_finder_dir, tumor_bam, tumor_bai ]
+// channel: skip: [ meta ]
+ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
+    ch_finder_out,
+    ch_tumor_rna_bam,
+)
+    .map { meta, neo_finder_dir, tumor_bam, tumor_bai ->
+        return [
+            meta,
+            neo_finder_dir,
+            params.realign_bam
+                ? tumor_bam
+                : Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
+            params.realign_bam
+                ? tumor_bai
+                : Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR),
+        ]
+    }
+    .branch { meta, neo_finder_dir, tumor_bam, tumor_bai ->
+        runnable: Utils.hasTumorRna(meta)
+            return [meta, neo_finder_dir, tumor_bam, tumor_bai]
+        skip: true
+            return meta
+    }

--- a/subworkflows/local/neo_prediction/main.nf
+++ b/subworkflows/local/neo_prediction/main.nf
@@ -1,28 +1,357 @@
-// NOTE: Full file not provided here because only one targeted block needs change and
-// minimizing file churn is best. Replace ONLY the block below in your existing file.
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Config file for defining DSL2 per module options and publishing paths
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Available keys to override module options:
+        ext.args   = Additional arguments appended to command in module.
+        ext.args2  = Second set of arguments appended to command in module (multi-tool modules).
+        ext.args3  = Third set of arguments appended to command in module (multi-tool modules).
+        ext.prefix = File name prefix for output files.
+----------------------------------------------------------------------------------------
+*/
 
-// Select input sources and sort for fusion annotation
-// channel: runnable: [ meta, neo_finder_dir, tumor_bam, tumor_bai ]
-// channel: skip: [ meta ]
-ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
-    ch_finder_out,
-    ch_tumor_rna_bam,
-)
-    .map { meta, neo_finder_dir, tumor_bam, tumor_bai ->
-        return [
-            meta,
-            neo_finder_dir,
-            params.realign_bam
-                ? tumor_bam
-                : Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
-            params.realign_bam
-                ? tumor_bai
-                : Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR),
+process {
+
+    withName: 'WRITE_REFERENCE_DATA' {
+        publishDir = [
+            path: { "${params.outdir}/reference_data/${workflow.manifest.version}" },
+            mode: params.publish_dir_mode,
         ]
     }
-    .branch { meta, neo_finder_dir, tumor_bam, tumor_bai ->
-        runnable: Utils.hasTumorRna(meta)
-            return [meta, neo_finder_dir, tumor_bam, tumor_bai]
-        skip: true
-            return meta
+
+    withName: 'FASTP' {
+        ext.args = '--disable_quality_filtering --disable_length_filtering --disable_adapter_trimming --disable_trim_poly_g'
     }
+
+    withName: 'STAR_GENOMEGENERATE' {
+        ext.args = '--genomeSAindexNbases 14 --sjdbOverhang 200 --genomeChrBinNbits 15'
+    }
+
+    withName: 'GATK4_MARKDUPLICATES' {
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/alignments/rna/${filename}") },
+        ]
+    }
+
+    withName: 'REDUX' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/alignments/dna/${filename}") },
+        ]
+    }
+
+    withName: 'AMBER' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
+        ]
+    }
+
+    withName: 'COBALT' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
+        ]
+    }
+
+    withName: '.*:ESVEE_CALLING:ESVEE' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
+        ]
+    }
+
+    withName: '.*:SAGE_CALLING:SAGE_GERMLINE' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/sage/${filename}") },
+        ]
+    }
+
+    withName: '.*:SAGE_CALLING:SAGE_SOMATIC' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/sage/${filename}") },
+        ]
+    }
+
+    withName: '.*:SAGE_APPEND:SAGE_APPEND_GERMLINE' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/sage_append/germline") },
+        ]
+    }
+
+    withName: '.*:SAGE_APPEND:SAGE_APPEND_SOMATIC' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/sage_append/somatic") },
+        ]
+    }
+
+    withName: '.*:PAVE_ANNOTATION:PAVE_(?:GERMLINE|SOMATIC)' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/pave/${filename}") },
+        ]
+    }
+
+    withName: 'PURPLE' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
+        ]
+    }
+
+    withName: '.*:LINX_ANNOTATION:LINX_GERMLINE' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/linx/germline_annotations/") },
+        ]
+    }
+
+    withName: '.*:LINX_ANNOTATION:LINX_SOMATIC' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/linx/somatic_annotations/") },
+        ]
+    }
+
+    withName: '.*:LINX_PLOTTING:LINX_VISUALISER' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/linx/somatic_plots/") },
+        ]
+    }
+
+    withName: '.*:LINX_PLOTTING:LINXREPORT' {
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/linx/${filename}") },
+        ]
+    }
+
+    withName: 'CIDER' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
+        ]
+    }
+
+    withName: 'BAMTOOLS' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename ->
+                def output_filename = filename.replaceFirst(/^bamtools_/, '');
+                get_saveas_path(meta, task, filename, "${meta.key}/bamtools/${output_filename}")
+            },
+        ]
+    }
+
+    withName: 'CHORD' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
+        ]
+    }
+
+    withName: 'LILAC' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
+        ]
+    }
+
+    withName: 'SIGS' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
+        ]
+    }
+
+    withName: 'TEAL.*' {
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.id}/teal/${new File(filename).name}") },
+        ]
+    }
+
+    withName: 'VIRUSBREAKEND' {
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/virusbreakend/${filename}") },
+        ]
+    }
+
+    withName: 'VIRUSINTERPRETER' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
+        ]
+    }
+
+    withName: 'ISOFOX' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
+        ]
+    }
+
+    withName: 'NEO_SCORER' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/neo/scorer/") },
+        ]
+    }
+
+    withName: '.*:NEO_PREDICTION:NEO_ANNOTATE_FUSIONS' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/neo/annotated_fusions/${filename}") },
+        ]
+    }
+
+    withName: 'NEO_FINDER' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/neo/finder/") },
+        ]
+    }
+
+    withName: 'WISP' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
+        ]
+    }
+
+    withName: 'CUPPA' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
+        ]
+    }
+
+    withName: 'PEACH' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/${filename}") },
+        ]
+    }
+
+    withName: 'ORANGE' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            // NOTE(SW): java.io.File and Nextflow's file do not work here, resorting to string splitting
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "${meta.key}/orange/${filename.split('[/]')[-1]}") },
+        ]
+    }
+
+    withName: 'COBALT_PANEL_NORMALISATION' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "panel_resources/${filename}", panel_resource_creation = true) },
+        ]
+    }
+
+    withName: 'PAVE_PON_PANEL_CREATION' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "panel_resources/${filename}", panel_resource_creation = true) },
+        ]
+    }
+
+    withName: 'ISOFOX_PANEL_NORMALISATION' {
+        ext.log_level = { "${params.hmftools_log_level}" }
+        publishDir = [
+            path: { "${params.outdir}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> get_saveas_path(meta, task, filename, "panel_resources/${filename}", panel_resource_creation = true) },
+        ]
+    }
+
+}
+
+def get_saveas_path(meta, task, filename, path, panel_resource_creation=false) {
+    if (filename.equals('versions.yml')) {
+        return null
+    } else if (filename.contains('.command.')) {
+        if (filename ==~ /.*\.command\.(sh|out|err|log|run)/) {
+            def process_name = task.process.toLowerCase().replaceFirst(/^.+:/, '')
+
+            if (panel_resource_creation) {
+                return "panel_resources/logs/${process_name}${filename}"
+            } else {
+                return "${meta.key}/logs/${meta.id}.${process_name}${filename}"
+            }
+
+        } else {
+            return null
+        }
+    } else {
+        return path
+    }
+}

--- a/subworkflows/local/neo_prediction/main.nf
+++ b/subworkflows/local/neo_prediction/main.nf
@@ -1,24 +1,24 @@
 //
-// NEO identifies and scores neoepitopes
+// Neo identifies and scores neoepitopes
 //
 
 import Constants
 import Utils
 
-include { NEO_FINDER            } from '../../../modules/local/neo/finder/main'
-include { NEO_ANNOTATE_FUSIONS  } from '../../../modules/local/neo/annotate_fusions/main'
-include { NEO_SCORER            } from '../../../modules/local/neo/scorer/main'
+include { NEO_ANNOTATE_FUSIONS } from '../../../modules/local/neo/annotate_fusions/main'
+include { NEO_FINDER           } from '../../../modules/local/neo/finder/main'
+include { NEO_SCORER           } from '../../../modules/local/neo/scorer/main'
 
 workflow NEO_PREDICTION {
     take:
     // Sample data
-    ch_inputs             // channel: [mandatory] [ meta ]
-    ch_tumor_rna_bam      // channel: [mandatory] [ meta, bam, bai ]
-    ch_isofox             // channel: [mandatory] [ meta, isofox_dir ]
-    ch_purple             // channel: [mandatory] [ meta, purple_dir ]
+    ch_inputs              // channel: [mandatory] [ meta ]
+    ch_tumor_rna_bam       // channel: [mandatory] [ meta, bam, bai ]
+    ch_isofox              // channel: [mandatory] [ meta, isofox_dir ]
+    ch_purple              // channel: [mandatory] [ meta, purple_dir ]
     ch_sage_somatic_append // channel: [mandatory] [ meta, sage_append_dir ]
-    ch_lilac              // channel: [mandatory] [ meta, lilac_dir ]
-    ch_linx_somatic       // channel: [mandatory] [ meta, linx_somatic_dir ]
+    ch_lilac               // channel: [mandatory] [ meta, lilac_dir ]
+    ch_linx                // channel: [mandatory] [ meta, linx_annotation_dir ]
 
     // Reference data
     genome_fasta           // channel: [mandatory] /path/to/genome_fasta
@@ -26,76 +26,95 @@ workflow NEO_PREDICTION {
     genome_fai             // channel: [mandatory] /path/to/genome_fai
     ensembl_data_resources // channel: [mandatory] /path/to/ensembl_data_resources/
     neo_resources          // channel: [mandatory] /path/to/neo_resources/
-    cohort_tpm_medians     // channel: [mandatory] /path/to/cohort_tpm_medians
+    cohort_tpm_medians     // channel: [mandatory] /path/to/cohort_tpm_medians/
 
     // Params
-    isofox_read_length     // integer: [mandatory] Isofox read length
+    isofox_read_length     //  string: [mandatory] Isofox read length
 
     main:
-    // Channel for version.yml files
+    // Channel for versions.yml files
     // channel: [ versions.yml ]
     ch_versions = Channel.empty()
 
     //
     // MODULE: Neo finder
     //
-    // Select input sources and sort
-    // channel: runnable: [ meta, purple_dir, lilac_dir, linx_somatic_dir ]
+// Select input sources and sort for fusion annotation
+// channel: runnable: [ meta, neo_finder_dir, tumor_bam, tumor_bai ]
+// channel: skip: [ meta ]
+ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
+    ch_finder_out,
+    ch_tumor_rna_bam,
+)
+    .map { meta, neo_finder_dir, tumor_bam, tumor_bai ->
+        return [
+            meta,
+            neo_finder_dir,
+            params.realign_bam
+                ? tumor_bam
+                : Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
+            params.realign_bam
+                ? tumor_bai
+                : Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR),
+        ]
+    }
+    .branch { meta, neo_finder_dir, tumor_bam, tumor_bai ->
+        runnable: Utils.hasTumorRna(meta)
+        skip: true
+            return meta
+    }
+
+    // Sort inputs
+    // channel: runnable: [ meta, purple_dir, linx_annotation_dir ]
     // channel: skip: [ meta ]
-    ch_finder_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
-        ch_purple,
-        ch_lilac,
-        ch_linx_somatic,
-    )
-        .map { meta, purple_dir, lilac_dir, linx_somatic_dir ->
-            return [
-                meta,
-                Utils.selectCurrentOrExisting(purple_dir, meta, Constants.INPUT.PURPLE_DIR),
-                Utils.selectCurrentOrExisting(lilac_dir, meta, Constants.INPUT.LILAC_DIR),
-                Utils.selectCurrentOrExisting(linx_somatic_dir, meta, Constants.INPUT.LINX_ANNO_DIR_TUMOR),
-            ]
-        }
-        .branch { meta, purple_dir, lilac_dir, linx_somatic_dir ->
-            runnable: Utils.hasTumorDna(meta)
+    ch_finder_inputs_sorted = ch_finder_inputs_selected
+        .branch { meta, purple_dir, linx_annotation_dir ->
+
+            def has_normal_dna = Utils.hasNormalDna(meta)
+
+            def has_runnable_inputs = purple_dir && linx_annotation_dir && has_normal_dna
+
+            runnable: has_runnable_inputs
             skip: true
                 return meta
         }
 
     // Create process input channel
-    // channel: [ meta_finder, purple_dir, lilac_dir, linx_somatic_dir ]
+    // channel: sample_data: [ meta_finder, purple_dir, linx_annotation_dir ]
     ch_finder_inputs = ch_finder_inputs_sorted.runnable
-        .map { meta, purple_dir, lilac_dir, linx_somatic_dir ->
+        .map { meta, purple_dir, linx_annotation_dir ->
 
             def meta_finder = [
                 key: meta.group_id,
                 id: meta.group_id,
-                sample_id: Utils.getTumorDnaSampleName(meta, primary: true),
+                sample_id: Utils.getTumorDnaSampleName(meta),
             ]
 
-            return [meta_finder, purple_dir, lilac_dir, linx_somatic_dir]
+            return [meta_finder, purple_dir, linx_annotation_dir]
         }
 
     // Run process
     NEO_FINDER(
         ch_finder_inputs,
-        neo_resources,
+        genome_fasta,
+        genome_version,
+        genome_fai,
+        ensembl_data_resources,
     )
 
     ch_versions = ch_versions.mix(NEO_FINDER.out.versions)
 
     // Set outputs, restoring original meta
     // channel: [ meta, neo_finder_dir ]
-    ch_finder_out = Channel.empty()
-        .mix(
-            WorkflowOncoanalyser.restoreMeta(NEO_FINDER.out.neo_finder_dir, ch_inputs),
-            ch_finder_inputs_sorted.skip.map { meta -> [meta, []] },
-        )
+    ch_finder_out = WorkflowOncoanalyser.restoreMeta(NEO_FINDER.out.neo_finder_dir, ch_inputs)
 
     //
-    // MODULE: Annotate fusions
+    // MODULE: Fusion annotation (Isofox)
     //
-    // Select input sources and sort for fusion annotation
-    // channel: runnable: [ meta, neo_finder_dir, tumor_bam, tumor_bai ]
+    // Annotate the fusion-derived neoepitope using Isofox where RNA data is available
+
+    // Select input sources and sort
+    // channel: runnable: [ meta, neo_finder_dir, tumor_bam_rna, tumor_bai_rna ]
     // channel: skip: [ meta ]
     ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
         ch_finder_out,
@@ -105,16 +124,13 @@ workflow NEO_PREDICTION {
             return [
                 meta,
                 neo_finder_dir,
-                params.realign_bam
-                    ? tumor_bam
-                    : Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
-                params.realign_bam
-                    ? tumor_bai
-                    : Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR),
+                Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
+                Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR),
             ]
         }
         .branch { meta, neo_finder_dir, tumor_bam, tumor_bai ->
             runnable: Utils.hasTumorRna(meta)
+                return [meta, neo_finder_dir, tumor_bam, tumor_bai]
             skip: true
                 return meta
         }
@@ -195,10 +211,16 @@ workflow NEO_PREDICTION {
 
             return [meta_scorer, *inputs]
         }
+        .branch { meta, isofox_dir, purple_dir, sage_somatic_append, lilac_dir, neo_finder_dir, annotated_fusions ->
+            runnable: purple_dir && neo_finder_dir && lilac_dir
+            skip: true
+                return meta
+        }
 
     // Run process
     NEO_SCORER(
-        ch_scorer_inputs,
+        ch_scorer_inputs.runnable,
+        ensembl_data_resources,
         neo_resources,
         cohort_tpm_medians,
     )

--- a/subworkflows/local/neo_prediction/main.nf
+++ b/subworkflows/local/neo_prediction/main.nf
@@ -1,24 +1,24 @@
 //
-// Neo identifies and scores neoepitopes
+// NEO identifies and scores neoepitopes
 //
 
 import Constants
 import Utils
 
-include { NEO_ANNOTATE_FUSIONS } from '../../../modules/local/neo/annotate_fusions/main'
-include { NEO_FINDER           } from '../../../modules/local/neo/finder/main'
-include { NEO_SCORER           } from '../../../modules/local/neo/scorer/main'
+include { NEO_FINDER            } from '../../../modules/local/neo/finder/main'
+include { NEO_ANNOTATE_FUSIONS  } from '../../../modules/local/neo/annotate_fusions/main'
+include { NEO_SCORER            } from '../../../modules/local/neo/scorer/main'
 
 workflow NEO_PREDICTION {
     take:
     // Sample data
-    ch_inputs              // channel: [mandatory] [ meta ]
-    ch_tumor_rna_bam       // channel: [mandatory] [ meta, bam, bai ]
-    ch_isofox              // channel: [mandatory] [ meta, isofox_dir ]
-    ch_purple              // channel: [mandatory] [ meta, purple_dir ]
+    ch_inputs             // channel: [mandatory] [ meta ]
+    ch_tumor_rna_bam      // channel: [mandatory] [ meta, bam, bai ]
+    ch_isofox             // channel: [mandatory] [ meta, isofox_dir ]
+    ch_purple             // channel: [mandatory] [ meta, purple_dir ]
     ch_sage_somatic_append // channel: [mandatory] [ meta, sage_append_dir ]
-    ch_lilac               // channel: [mandatory] [ meta, lilac_dir ]
-    ch_linx                // channel: [mandatory] [ meta, linx_annotation_dir ]
+    ch_lilac              // channel: [mandatory] [ meta, lilac_dir ]
+    ch_linx_somatic       // channel: [mandatory] [ meta, linx_somatic_dir ]
 
     // Reference data
     genome_fasta           // channel: [mandatory] /path/to/genome_fasta
@@ -26,143 +26,99 @@ workflow NEO_PREDICTION {
     genome_fai             // channel: [mandatory] /path/to/genome_fai
     ensembl_data_resources // channel: [mandatory] /path/to/ensembl_data_resources/
     neo_resources          // channel: [mandatory] /path/to/neo_resources/
-    cohort_tpm_medians     // channel: [mandatory] /path/to/cohort_tpm_medians/
+    cohort_tpm_medians     // channel: [mandatory] /path/to/cohort_tpm_medians
 
     // Params
-    isofox_read_length     //  string: [mandatory] Isofox read length
+    isofox_read_length     // integer: [mandatory] Isofox read length
 
     main:
-    // Channel for versions.yml files
+    // Channel for version.yml files
     // channel: [ versions.yml ]
     ch_versions = Channel.empty()
 
     //
     // MODULE: Neo finder
     //
-    // Select input sources
-    // channel: [ meta, purple_dir, linx_annotation_dir ]
-    ch_finder_inputs_selected = WorkflowOncoanalyser.groupByMeta(
-        ch_purple,
-        ch_linx,
-    )
-        .map { meta, purple_dir, linx_annotation_dir ->
-
-            def inputs = [
-                Utils.selectCurrentOrExisting(purple_dir, meta, Constants.INPUT.PURPLE_DIR),
-                Utils.selectCurrentOrExisting(linx_annotation_dir, meta, Constants.INPUT.LINX_ANNO_DIR_TUMOR),
-            ]
-
-            return [meta, *inputs]
-        }
-
-    // Sort inputs
-    // channel: runnable: [ meta, purple_dir, linx_annotation_dir ]
+    // Select input sources and sort
+    // channel: runnable: [ meta, purple_dir, lilac_dir, linx_somatic_dir ]
     // channel: skip: [ meta ]
-    ch_finder_inputs_sorted = ch_finder_inputs_selected
-        .branch { meta, purple_dir, linx_annotation_dir ->
-
-            def has_normal_dna = Utils.hasNormalDna(meta)
-
-            def has_runnable_inputs = purple_dir && linx_annotation_dir && has_normal_dna
-
-            runnable: has_runnable_inputs
+    ch_finder_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
+        ch_purple,
+        ch_lilac,
+        ch_linx_somatic,
+    )
+        .map { meta, purple_dir, lilac_dir, linx_somatic_dir ->
+            return [
+                meta,
+                Utils.selectCurrentOrExisting(purple_dir, meta, Constants.INPUT.PURPLE_DIR),
+                Utils.selectCurrentOrExisting(lilac_dir, meta, Constants.INPUT.LILAC_DIR),
+                Utils.selectCurrentOrExisting(linx_somatic_dir, meta, Constants.INPUT.LINX_ANNO_DIR_TUMOR),
+            ]
+        }
+        .branch { meta, purple_dir, lilac_dir, linx_somatic_dir ->
+            runnable: Utils.hasTumorDna(meta)
             skip: true
                 return meta
         }
 
     // Create process input channel
-    // channel: sample_data: [ meta_finder, purple_dir, linx_annotation_dir ]
+    // channel: [ meta_finder, purple_dir, lilac_dir, linx_somatic_dir ]
     ch_finder_inputs = ch_finder_inputs_sorted.runnable
-        .map { meta, purple_dir, linx_annotation_dir ->
+        .map { meta, purple_dir, lilac_dir, linx_somatic_dir ->
 
             def meta_finder = [
                 key: meta.group_id,
                 id: meta.group_id,
-                sample_id: Utils.getTumorDnaSampleName(meta),
+                sample_id: Utils.getTumorDnaSampleName(meta, primary: true),
             ]
 
-            return [meta_finder, purple_dir, linx_annotation_dir]
+            return [meta_finder, purple_dir, lilac_dir, linx_somatic_dir]
         }
 
     // Run process
     NEO_FINDER(
         ch_finder_inputs,
-        genome_fasta,
-        genome_version,
-        genome_fai,
-        ensembl_data_resources,
+        neo_resources,
     )
 
     ch_versions = ch_versions.mix(NEO_FINDER.out.versions)
 
     // Set outputs, restoring original meta
     // channel: [ meta, neo_finder_dir ]
-    ch_finder_out = WorkflowOncoanalyser.restoreMeta(NEO_FINDER.out.neo_finder_dir, ch_inputs)
+    ch_finder_out = Channel.empty()
+        .mix(
+            WorkflowOncoanalyser.restoreMeta(NEO_FINDER.out.neo_finder_dir, ch_inputs),
+            ch_finder_inputs_sorted.skip.map { meta -> [meta, []] },
+        )
 
     //
-    // MODULE: Fusion annotation (Isofox)
+    // MODULE: Annotate fusions
     //
-    // Annotate the fusion-derived neoepitope using Isofox where RNA data is available
-
-    // Select input sources and sort
-    // channel: runnable: [ meta, neo_finder_dir, tumor_bam_rna, tumor_bai_rna ]
-    // channel: skip: [ meta ]
     // Select input sources and sort for fusion annotation
-// channel: runnable: [ meta, neo_finder_dir, tumor_bam, tumor_bai ]
-// channel: skip: [ meta ]
-ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
-    ch_finder_out,
-    ch_tumor_rna_bam,
-)
-    .map { meta, neo_finder_dir, tumor_bam, tumor_bai ->
-        return [
-            meta,
-            neo_finder_dir,
-            params.realign_bam
-                ? tumor_bam
-                : Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
-            params.realign_bam
-                ? tumor_bai
-                : Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR),
-        ]
-    }
-    .branch { meta, neo_finder_dir, tumor_bam, tumor_bai ->
-        runnable: Utils.hasTumorRna(meta)
-        skip: true
-            return meta
-    }
-The only behavioral change is:
+    // channel: runnable: [ meta, neo_finder_dir, tumor_bam, tumor_bai ]
+    // channel: skip: [ meta ]
+    ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
+        ch_finder_out,
+        ch_tumor_rna_bam,
+    )
+        .map { meta, neo_finder_dir, tumor_bam, tumor_bai ->
+            return [
+                meta,
+                neo_finder_dir,
+                params.realign_bam
+                    ? tumor_bam
+                    : Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
+                params.realign_bam
+                    ? tumor_bai
+                    : Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR),
+            ]
+        }
+        .branch { meta, neo_finder_dir, tumor_bam, tumor_bai ->
+            runnable: Utils.hasTumorRna(meta)
+            skip: true
+                return meta
+        }
 
-when params.realign_bam == true, use tumor_bam/tumor_bai from upstream channel (realigned output),
-otherwise preserve existing fallback behavior.
-Also, yes — this is the snippet you provided:
-
-Nextflow
-// Select input sources and sort for fusion annotation
-// channel: runnable: [ meta, neo_finder_dir, tumor_bam, tumor_bai ]
-// channel: skip: [ meta ]
-ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
-    ch_finder_out,
-    ch_tumor_rna_bam,
-)
-    .map { meta, neo_finder_dir, tumor_bam, tumor_bai ->
-        return [
-            meta,
-            neo_finder_dir,
-            params.realign_bam
-                ? tumor_bam
-                : Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
-            params.realign_bam
-                ? tumor_bai
-                : Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR),
-        ]
-    }
-    .branch { meta, neo_finder_dir, tumor_bam, tumor_bai ->
-        runnable: Utils.hasTumorRna(meta)
-            return [meta, neo_finder_dir, tumor_bam, tumor_bai]
-        skip: true
-            return meta
-    }
     // Create process input channel
     // channel: [ meta_isofox, neo_finder_dir, tumor_bam_rna, tumor_bai_rna ]
     ch_isofox_inputs = ch_isofox_inputs_sorted.runnable
@@ -239,16 +195,10 @@ ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
 
             return [meta_scorer, *inputs]
         }
-        .branch { meta, isofox_dir, purple_dir, sage_somatic_append, lilac_dir, neo_finder_dir, annotated_fusions ->
-            runnable: purple_dir && neo_finder_dir && lilac_dir
-            skip: true
-                return meta
-        }
 
     // Run process
     NEO_SCORER(
-        ch_scorer_inputs.runnable,
-        ensembl_data_resources,
+        ch_scorer_inputs,
         neo_resources,
         cohort_tpm_medians,
     )

--- a/subworkflows/local/neo_prediction/main.nf
+++ b/subworkflows/local/neo_prediction/main.nf
@@ -55,30 +55,20 @@ workflow NEO_PREDICTION {
             return [meta, *inputs]
         }
 
-    // Sort inputs and select based on whether realigned bam is available
-    // channel: runnable: [ meta, neo_finder_dir, tumor_bam, tumor_bai ]
+    // Sort inputs
+    // channel: runnable: [ meta, purple_dir, linx_annotation_dir ]
     // channel: skip: [ meta ]
-ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
-    ch_finder_out,
-    ch_tumor_rna_bam,
-)
-    .map { meta, neo_finder_dir, tumor_bam, tumor_bai ->
-        return [
-            meta,
-            neo_finder_dir,
-            params.realign_bam
-                ? tumor_bam
-                : Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
-            params.realign_bam
-                ? tumor_bai
-                : Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR),
-        ]
-    }
-    .branch { meta, neo_finder_dir, tumor_bam, tumor_bai ->
-        runnable: Utils.hasTumorRna(meta)
-        skip: true
-            return meta
-    }
+    ch_finder_inputs_sorted = ch_finder_inputs_selected
+        .branch { meta, purple_dir, linx_annotation_dir ->
+
+            def has_normal_dna = Utils.hasNormalDna(meta)
+
+            def has_runnable_inputs = purple_dir && linx_annotation_dir && has_normal_dna
+
+            runnable: has_runnable_inputs
+            skip: true
+                return meta
+        }
 
     // Create process input channel
     // channel: sample_data: [ meta_finder, purple_dir, linx_annotation_dir ]
@@ -115,7 +105,7 @@ ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
     // Annotate the fusion-derived neoepitope using Isofox where RNA data is available
 
     // Select input sources and sort
-    // channel: runnable: [ meta, neo_finder_dir, tumor_bam_rna, tumor_bai_rna ]
+    // channel: runnable: [ meta, neo_finder_dir, tumor_bam, tumor_bai ]
     // channel: skip: [ meta ]
     ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
         ch_finder_out,
@@ -125,13 +115,16 @@ ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
             return [
                 meta,
                 neo_finder_dir,
-                Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
-                Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR),
+                params.realign_bam
+                    ? tumor_bam
+                    : Utils.selectCurrentOrExisting(tumor_bam, meta, Constants.INPUT.BAM_RNA_TUMOR),
+                params.realign_bam
+                    ? tumor_bai
+                    : Utils.selectCurrentOrExisting(tumor_bai, meta, Constants.INPUT.BAI_RNA_TUMOR),
             ]
         }
         .branch { meta, neo_finder_dir, tumor_bam, tumor_bai ->
             runnable: Utils.hasTumorRna(meta)
-                return [meta, neo_finder_dir, tumor_bam, tumor_bai]
             skip: true
                 return meta
         }

--- a/subworkflows/local/neo_prediction/main.nf
+++ b/subworkflows/local/neo_prediction/main.nf
@@ -39,9 +39,25 @@ workflow NEO_PREDICTION {
     //
     // MODULE: Neo finder
     //
-// Select input sources and sort for fusion annotation
-// channel: runnable: [ meta, neo_finder_dir, tumor_bam, tumor_bai ]
-// channel: skip: [ meta ]
+    // Select input sources
+    // channel: [ meta, purple_dir, linx_annotation_dir ]
+    ch_finder_inputs_selected = WorkflowOncoanalyser.groupByMeta(
+        ch_purple,
+        ch_linx,
+    )
+        .map { meta, purple_dir, linx_annotation_dir ->
+
+            def inputs = [
+                Utils.selectCurrentOrExisting(purple_dir, meta, Constants.INPUT.PURPLE_DIR),
+                Utils.selectCurrentOrExisting(linx_annotation_dir, meta, Constants.INPUT.LINX_ANNO_DIR_TUMOR),
+            ]
+
+            return [meta, *inputs]
+        }
+
+    // Sort inputs and select based on whether realigned bam is available
+    // channel: runnable: [ meta, neo_finder_dir, tumor_bam, tumor_bai ]
+    // channel: skip: [ meta ]
 ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
     ch_finder_out,
     ch_tumor_rna_bam,
@@ -63,21 +79,6 @@ ch_isofox_inputs_sorted = WorkflowOncoanalyser.groupByMeta(
         skip: true
             return meta
     }
-
-    // Sort inputs
-    // channel: runnable: [ meta, purple_dir, linx_annotation_dir ]
-    // channel: skip: [ meta ]
-    ch_finder_inputs_sorted = ch_finder_inputs_selected
-        .branch { meta, purple_dir, linx_annotation_dir ->
-
-            def has_normal_dna = Utils.hasNormalDna(meta)
-
-            def has_runnable_inputs = purple_dir && linx_annotation_dir && has_normal_dna
-
-            runnable: has_runnable_inputs
-            skip: true
-                return meta
-        }
 
     // Create process input channel
     // channel: sample_data: [ meta_finder, purple_dir, linx_annotation_dir ]

--- a/subworkflows/local/prepare_inputs/main.nf
+++ b/subworkflows/local/prepare_inputs/main.nf
@@ -16,7 +16,7 @@ workflow PREPARE_INPUTS {
 
     main:
     ch_inputs = Channel.fromList(
-        Utils.parseInput(input_fp_str, workflow.stubRun, log)
+        Utils.parseInput(input_fp_str, workflow.stubRun, params.realign_bam, log)
     )
 
     emit:

--- a/subworkflows/local/read_alignment_dna_from_bam/main.nf
+++ b/subworkflows/local/read_alignment_dna_from_bam/main.nf
@@ -20,7 +20,7 @@ workflow READ_ALIGNMENT_DNA_FROM_BAM {
     main:
     ch_versions = Channel.empty()
 
-    // Branch inputs: only process samples that have a BAM but no existing realigned output
+    // Branch inputs: process samples that have BAM/CRAM inputs
     ch_inputs_tumor_sorted = ch_inputs
         .branch { meta ->
             runnable: Utils.hasTumorDnaBam(meta)
@@ -39,7 +39,7 @@ workflow READ_ALIGNMENT_DNA_FROM_BAM {
             skip: true
         }
 
-    // Build a flat channel of [ meta_bwamem2, bam ] — one entry per read-group in the source BAM.
+    // Build a flat channel of [ meta_bwamem2, bam ] from input BAM/CRAM.
     ch_bwamem2_inputs = Channel.empty()
         .mix(
             ch_inputs_tumor_sorted.runnable.map { meta ->
@@ -52,7 +52,9 @@ workflow READ_ALIGNMENT_DNA_FROM_BAM {
                     sample_type: 'tumor',
                     read_group:  "${sample_id}.realign",
                 ]
-                return [meta_bwamem2, Utils.getTumorDnaBam(meta)]
+                def bam = Utils.getTumorDnaBam(meta)
+                assert bam != null && bam != [] : "Missing tumor DNA BAM/CRAM for ${meta.group_id}"
+                return [meta_bwamem2, bam]
             },
             ch_inputs_normal_sorted.runnable.map { meta ->
                 def meta_sample = Utils.getNormalDnaSample(meta)
@@ -64,7 +66,9 @@ workflow READ_ALIGNMENT_DNA_FROM_BAM {
                     sample_type: 'normal',
                     read_group:  "${sample_id}.realign",
                 ]
-                return [meta_bwamem2, Utils.getNormalDnaBam(meta)]
+                def bam = Utils.getNormalDnaBam(meta)
+                assert bam != null && bam != [] : "Missing normal DNA BAM/CRAM for ${meta.group_id}"
+                return [meta_bwamem2, bam]
             },
             ch_inputs_donor_sorted.runnable.map { meta ->
                 def meta_sample = Utils.getDonorDnaSample(meta)
@@ -76,9 +80,12 @@ workflow READ_ALIGNMENT_DNA_FROM_BAM {
                     sample_type: 'donor',
                     read_group:  "${sample_id}.realign",
                 ]
-                return [meta_bwamem2, Utils.getDonorDnaBam(meta)]
+                def bam = Utils.getDonorDnaBam(meta)
+                assert bam != null && bam != [] : "Missing donor DNA BAM/CRAM for ${meta.group_id}"
+                return [meta_bwamem2, bam]
             },
         )
+        .filter { meta_bwamem2, bam -> bam != null && bam != [] }
 
     BWAMEM2_ALIGN_FROM_BAM(
         ch_bwamem2_inputs,

--- a/subworkflows/local/read_alignment_dna_from_bam/main.nf
+++ b/subworkflows/local/read_alignment_dna_from_bam/main.nf
@@ -23,22 +23,19 @@ workflow READ_ALIGNMENT_DNA_FROM_BAM {
     // Branch inputs: only process samples that have a BAM but no existing realigned output
     ch_inputs_tumor_sorted = ch_inputs
         .branch { meta ->
-            def has_existing = Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_TUMOR)
-            runnable: Utils.hasTumorDnaBam(meta) && !has_existing
+            runnable: Utils.hasTumorDnaBam(meta)
             skip: true
         }
 
     ch_inputs_normal_sorted = ch_inputs
         .branch { meta ->
-            def has_existing = Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_NORMAL)
-            runnable: Utils.hasNormalDnaBam(meta) && !has_existing
+            runnable: Utils.hasNormalDnaBam(meta)
             skip: true
         }
 
     ch_inputs_donor_sorted = ch_inputs
         .branch { meta ->
-            def has_existing = Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_DONOR)
-            runnable: Utils.hasDonorDnaBam(meta) && !has_existing
+            runnable: Utils.hasDonorDnaBam(meta)
             skip: true
         }
 

--- a/subworkflows/local/read_alignment_dna_from_bam/main.nf
+++ b/subworkflows/local/read_alignment_dna_from_bam/main.nf
@@ -1,0 +1,143 @@
+//
+// Align DNA reads from an existing BAM/CRAM by streaming through samtools fastq
+// Note: this does not include the option to chunk up the bam, as is available in the FASTQ-based workflow.
+//
+
+import Constants
+import Utils
+
+include { BWAMEM2_ALIGN_FROM_BAM } from '../../../modules/local/bwa-mem2/mem_from_bam/main'
+
+workflow READ_ALIGNMENT_DNA_FROM_BAM {
+    take:
+    // Sample data
+    ch_inputs            // channel: [mandatory] [ meta ]
+
+    // Reference data
+    genome_fasta         // channel: [mandatory] /path/to/genome_fasta
+    genome_bwamem2_index // channel: [mandatory] /path/to/genome_bwa-mem2_index_dir/
+
+    main:
+    ch_versions = Channel.empty()
+
+    // Branch inputs: only process samples that have a BAM but no existing realigned output
+    ch_inputs_tumor_sorted = ch_inputs
+        .branch { meta ->
+            def has_existing = Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_TUMOR)
+            runnable: Utils.hasTumorDnaBam(meta) && !has_existing
+            skip: true
+        }
+
+    ch_inputs_normal_sorted = ch_inputs
+        .branch { meta ->
+            def has_existing = Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_NORMAL)
+            runnable: Utils.hasNormalDnaBam(meta) && !has_existing
+            skip: true
+        }
+
+    ch_inputs_donor_sorted = ch_inputs
+        .branch { meta ->
+            def has_existing = Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_DONOR)
+            runnable: Utils.hasDonorDnaBam(meta) && !has_existing
+            skip: true
+        }
+
+    // Build a flat channel of [ meta_bwamem2, bam ] — one entry per read-group in the source BAM.
+    ch_bwamem2_inputs = Channel.empty()
+        .mix(
+            ch_inputs_tumor_sorted.runnable.map { meta ->
+                def meta_sample = Utils.getTumorDnaSample(meta)
+                def sample_id   = meta_sample.getOrDefault('longitudinal_sample_id', meta_sample['sample_id'])
+                def meta_bwamem2 = [
+                    key:         meta.group_id,
+                    id:          "${meta.group_id}_${sample_id}",
+                    sample_id:   sample_id,
+                    sample_type: 'tumor',
+                    read_group:  "${sample_id}.realign",
+                ]
+                return [meta_bwamem2, Utils.getTumorDnaBam(meta)]
+            },
+            ch_inputs_normal_sorted.runnable.map { meta ->
+                def meta_sample = Utils.getNormalDnaSample(meta)
+                def sample_id   = meta_sample['sample_id']
+                def meta_bwamem2 = [
+                    key:         meta.group_id,
+                    id:          "${meta.group_id}_${sample_id}",
+                    sample_id:   sample_id,
+                    sample_type: 'normal',
+                    read_group:  "${sample_id}.realign",
+                ]
+                return [meta_bwamem2, Utils.getNormalDnaBam(meta)]
+            },
+            ch_inputs_donor_sorted.runnable.map { meta ->
+                def meta_sample = Utils.getDonorDnaSample(meta)
+                def sample_id   = meta_sample['sample_id']
+                def meta_bwamem2 = [
+                    key:         meta.group_id,
+                    id:          "${meta.group_id}_${sample_id}",
+                    sample_id:   sample_id,
+                    sample_type: 'donor',
+                    read_group:  "${sample_id}.realign",
+                ]
+                return [meta_bwamem2, Utils.getDonorDnaBam(meta)]
+            },
+        )
+
+    BWAMEM2_ALIGN_FROM_BAM(
+        ch_bwamem2_inputs,
+        genome_fasta,
+        genome_bwamem2_index,
+    )
+
+    ch_versions = ch_versions.mix(BWAMEM2_ALIGN_FROM_BAM.out.versions)
+
+    // Reunite BAMs (count = 1 per sample for simple single-BAM-in case)
+    ch_sample_counts = ch_bwamem2_inputs
+        .map { meta_bwamem2, bam -> [[key: meta_bwamem2.key, sample_type: meta_bwamem2.sample_type], meta_bwamem2] }
+        .groupTuple()
+        .map { meta_count, metas -> [meta_count, metas.size()] }
+
+    ch_bams_united = ch_sample_counts
+        .cross(
+            BWAMEM2_ALIGN_FROM_BAM.out.bam
+                .map { meta_bwamem2, bam, bai -> [[key: meta_bwamem2.key, sample_type: meta_bwamem2.sample_type], bam, bai] }
+        )
+        .map { count_tuple, bam_tuple ->
+            def group_size = count_tuple[1]
+            def (meta_bam, bam, bai) = bam_tuple
+            return tuple(groupKey([*:meta_bam], group_size), bam, bai)
+        }
+        .groupTuple()
+        .branch { meta_group, bams, bais ->
+            assert ['tumor', 'normal', 'donor'].contains(meta_group.sample_type)
+            tumor:  meta_group.sample_type == 'tumor'
+            normal: meta_group.sample_type == 'normal'
+            donor:  meta_group.sample_type == 'donor'
+            placeholder: true
+        }
+
+    ch_bam_tumor_out = Channel.empty()
+        .mix(
+            WorkflowOncoanalyser.restoreMeta(ch_bams_united.tumor,  ch_inputs),
+            ch_inputs_tumor_sorted.skip.map  { meta -> [meta, [], []] },
+        )
+
+    ch_bam_normal_out = Channel.empty()
+        .mix(
+            WorkflowOncoanalyser.restoreMeta(ch_bams_united.normal, ch_inputs),
+            ch_inputs_normal_sorted.skip.map { meta -> [meta, [], []] },
+        )
+
+    ch_bam_donor_out = Channel.empty()
+        .mix(
+            WorkflowOncoanalyser.restoreMeta(ch_bams_united.donor,  ch_inputs),
+            ch_inputs_donor_sorted.skip.map  { meta -> [meta, [], []] },
+        )
+
+    emit:
+    dna_tumor  = ch_bam_tumor_out   // channel: [ meta, [bam, ...], [bai, ...] ]
+    dna_normal = ch_bam_normal_out  // channel: [ meta, [bam, ...], [bai, ...] ]
+    dna_donor  = ch_bam_donor_out   // channel: [ meta, [bam, ...], [bai, ...] ]
+
+    versions   = ch_versions        // channel: [ versions.yml ]
+}

--- a/subworkflows/local/read_alignment_rna_from_bam/main.nf
+++ b/subworkflows/local/read_alignment_rna_from_bam/main.nf
@@ -26,8 +26,7 @@ workflow READ_ALIGNMENT_RNA_FROM_BAM {
     // channel: [ meta ]
     ch_inputs_sorted = ch_inputs
         .branch { meta ->
-            def has_existing = Utils.hasExistingInput(meta, Constants.INPUT.BAM_RNA_TUMOR)
-            runnable: Utils.hasTumorRnaBam(meta) && !has_existing
+            runnable: Utils.hasTumorRnaBam(meta)
             skip: true
         }
 

--- a/subworkflows/local/read_alignment_rna_from_bam/main.nf
+++ b/subworkflows/local/read_alignment_rna_from_bam/main.nf
@@ -1,0 +1,95 @@
+//
+// Align RNA reads from an existing BAM by streaming through samtools fastq into STAR
+//
+
+import Constants
+import Utils
+
+include { GATK4_MARKDUPLICATES  } from '../../../modules/nf-core/gatk4/markduplicates/main'
+include { SAMTOOLS_SORT         } from '../../../modules/nf-core/samtools/sort/main'
+include { STAR_ALIGN_FROM_BAM   } from '../../../modules/local/star/align_from_bam/main'
+
+workflow READ_ALIGNMENT_RNA_FROM_BAM {
+    take:
+    // Sample data
+    ch_inputs         // channel: [mandatory] [ meta ]
+
+    // Reference data
+    genome_star_index // channel: [mandatory] /path/to/genome_star_index/
+
+    main:
+    // Channel for version.yml files
+    // channel: [ versions.yml ]
+    ch_versions = Channel.empty()
+
+    // Sort inputs
+    // channel: [ meta ]
+    ch_inputs_sorted = ch_inputs
+        .branch { meta ->
+            def has_existing = Utils.hasExistingInput(meta, Constants.INPUT.BAM_RNA_TUMOR)
+            runnable: Utils.hasTumorRnaBam(meta) && !has_existing
+            skip: true
+        }
+
+    // Create BAM/CRAM input channel for STAR_ALIGN_FROM_BAM
+    // channel: [ meta_star, bam ]
+    ch_star_inputs = ch_inputs_sorted.runnable
+        .map { meta ->
+            def meta_sample = Utils.getTumorRnaSample(meta)
+            def meta_star = [
+                key:        meta.group_id,
+                id:         "${meta.group_id}_${meta_sample.sample_id}",
+                sample_id:  meta_sample.sample_id,
+                read_group: "${meta_sample.sample_id}.realign",
+            ]
+            return [meta_star, Utils.getTumorRnaBam(meta)]
+        }
+
+    STAR_ALIGN_FROM_BAM(
+        ch_star_inputs,
+        genome_star_index,
+    )
+
+    ch_versions = ch_versions.mix(STAR_ALIGN_FROM_BAM.out.versions)
+
+    // Sort the unsorted BAM output from STAR
+    ch_sort_inputs = STAR_ALIGN_FROM_BAM.out.bam
+        .map { meta_star, bam ->
+            [[ *:meta_star, prefix: meta_star.read_group ], bam]
+        }
+
+    SAMTOOLS_SORT(ch_sort_inputs)
+
+    ch_versions = ch_versions.mix(SAMTOOLS_SORT.out.versions)
+
+    // Markduplicates (single BAM per sample, no merge needed)
+    ch_markdups_inputs = WorkflowOncoanalyser.restoreMeta(SAMTOOLS_SORT.out.bam, ch_inputs)
+        .map { meta, bam ->
+            def meta_markdups = [
+                key:       meta.group_id,
+                id:        meta.group_id,
+                sample_id: Utils.getTumorRnaSampleName(meta),
+            ]
+            return [meta_markdups, bam]
+        }
+
+    GATK4_MARKDUPLICATES(ch_markdups_inputs, [], [])
+
+    ch_versions = ch_versions.mix(GATK4_MARKDUPLICATES.out.versions)
+
+    ch_bams_ready = WorkflowOncoanalyser.groupByMeta(
+        WorkflowOncoanalyser.restoreMeta(GATK4_MARKDUPLICATES.out.bam, ch_inputs),
+        WorkflowOncoanalyser.restoreMeta(GATK4_MARKDUPLICATES.out.bai, ch_inputs),
+    )
+
+    ch_bam_out = Channel.empty()
+        .mix(
+            ch_bams_ready,
+            ch_inputs_sorted.skip.map { meta -> [meta, [], []] },
+        )
+
+    emit:
+    rna_tumor = ch_bam_out   // channel: [ meta, bam, bai ]
+
+    versions  = ch_versions  // channel: [ versions.yml ]
+}

--- a/subworkflows/local/redux_processing/main.nf
+++ b/subworkflows/local/redux_processing/main.nf
@@ -32,20 +32,15 @@ workflow REDUX_PROCESSING {
     // channel: [ versions.yml ]
     ch_versions = Channel.empty()
 
-    // Select and sort input sources, separating bytumor and normal
+    // Select and sort input sources, separating by tumor and normal
     // channel: runnable: [ meta, [bam, ...], [bai, ...] ]
     // channel: skip: [ meta ]
     ch_inputs_tumor_sorted = ch_dna_tumor
         .map { meta, bams, bais ->
             return [
                 meta,
-                // In realign mode, prefer the current upstream alignment output over original BAM/CRAM input
-                params.realign_bam
-                    ? bams
-                    : (Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_TUMOR) ? [Utils.getInput(meta, Constants.INPUT.BAM_DNA_TUMOR)] : bams),
-                params.realign_bam
-                    ? bais
-                    : (Utils.hasExistingInput(meta, Constants.INPUT.BAI_DNA_TUMOR) ? [Utils.getInput(meta, Constants.INPUT.BAI_DNA_TUMOR)] : bais),
+                params.realign_bam ? bams : (Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_TUMOR) ? [Utils.getInput(meta, Constants.INPUT.BAM_DNA_TUMOR)] : bams),
+                params.realign_bam ? bais : (Utils.hasExistingInput(meta, Constants.INPUT.BAI_DNA_TUMOR) ? [Utils.getInput(meta, Constants.INPUT.BAI_DNA_TUMOR)] : bais),
             ]
         }
         .branch { meta, bams, bais ->
@@ -59,13 +54,8 @@ workflow REDUX_PROCESSING {
         .map { meta, bams, bais ->
             return [
                 meta,
-                // In realign mode, prefer the current upstream alignment output over original BAM/CRAM input
-                params.realign_bam
-                    ? bams
-                    : (Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_NORMAL) ? [Utils.getInput(meta, Constants.INPUT.BAM_DNA_NORMAL)] : bams),
-                params.realign_bam
-                    ? bais
-                    : (Utils.hasExistingInput(meta, Constants.INPUT.BAI_DNA_NORMAL) ? [Utils.getInput(meta, Constants.INPUT.BAI_DNA_NORMAL)] : bais),
+                params.realign_bam ? bams : (Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_NORMAL) ? [Utils.getInput(meta, Constants.INPUT.BAM_DNA_NORMAL)] : bams),
+                params.realign_bam ? bais : (Utils.hasExistingInput(meta, Constants.INPUT.BAI_DNA_NORMAL) ? [Utils.getInput(meta, Constants.INPUT.BAI_DNA_NORMAL)] : bais),
             ]
         }
         .branch { meta, bams, bais ->
@@ -79,13 +69,8 @@ workflow REDUX_PROCESSING {
         .map { meta, bams, bais ->
             return [
                 meta,
-                // In realign mode, prefer the current upstream alignment output over original BAM/CRAM input
-                params.realign_bam
-                    ? bams
-                    : (Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_DONOR) ? [Utils.getInput(meta, Constants.INPUT.BAM_DNA_DONOR)] : bams),
-                params.realign_bam
-                    ? bais
-                    : (Utils.hasExistingInput(meta, Constants.INPUT.BAI_DNA_DONOR) ? [Utils.getInput(meta, Constants.INPUT.BAI_DNA_DONOR)] : bais),
+                params.realign_bam ? bams : (Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_DONOR) ? [Utils.getInput(meta, Constants.INPUT.BAM_DNA_DONOR)] : bams),
+                params.realign_bam ? bais : (Utils.hasExistingInput(meta, Constants.INPUT.BAI_DNA_DONOR) ? [Utils.getInput(meta, Constants.INPUT.BAI_DNA_DONOR)] : bais),
             ]
         }
         .branch { meta, bams, bais ->

--- a/subworkflows/local/redux_processing/main.nf
+++ b/subworkflows/local/redux_processing/main.nf
@@ -39,8 +39,13 @@ workflow REDUX_PROCESSING {
         .map { meta, bams, bais ->
             return [
                 meta,
-                Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_TUMOR) ? [Utils.getInput(meta, Constants.INPUT.BAM_DNA_TUMOR)] : bams,
-                Utils.hasExistingInput(meta, Constants.INPUT.BAI_DNA_TUMOR) ? [Utils.getInput(meta, Constants.INPUT.BAI_DNA_TUMOR)] : bais,
+                // In realign mode, prefer the current upstream alignment output over original BAM/CRAM input
+                params.realign_bam
+                    ? bams
+                    : (Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_TUMOR) ? [Utils.getInput(meta, Constants.INPUT.BAM_DNA_TUMOR)] : bams),
+                params.realign_bam
+                    ? bais
+                    : (Utils.hasExistingInput(meta, Constants.INPUT.BAI_DNA_TUMOR) ? [Utils.getInput(meta, Constants.INPUT.BAI_DNA_TUMOR)] : bais),
             ]
         }
         .branch { meta, bams, bais ->
@@ -54,8 +59,13 @@ workflow REDUX_PROCESSING {
         .map { meta, bams, bais ->
             return [
                 meta,
-                Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_NORMAL) ? [Utils.getInput(meta, Constants.INPUT.BAM_DNA_NORMAL)] : bams,
-                Utils.hasExistingInput(meta, Constants.INPUT.BAI_DNA_NORMAL) ? [Utils.getInput(meta, Constants.INPUT.BAI_DNA_NORMAL)] : bais,
+                // In realign mode, prefer the current upstream alignment output over original BAM/CRAM input
+                params.realign_bam
+                    ? bams
+                    : (Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_NORMAL) ? [Utils.getInput(meta, Constants.INPUT.BAM_DNA_NORMAL)] : bams),
+                params.realign_bam
+                    ? bais
+                    : (Utils.hasExistingInput(meta, Constants.INPUT.BAI_DNA_NORMAL) ? [Utils.getInput(meta, Constants.INPUT.BAI_DNA_NORMAL)] : bais),
             ]
         }
         .branch { meta, bams, bais ->
@@ -69,8 +79,13 @@ workflow REDUX_PROCESSING {
         .map { meta, bams, bais ->
             return [
                 meta,
-                Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_DONOR) ? [Utils.getInput(meta, Constants.INPUT.BAM_DNA_DONOR)] : bams,
-                Utils.hasExistingInput(meta, Constants.INPUT.BAI_DNA_DONOR) ? [Utils.getInput(meta, Constants.INPUT.BAI_DNA_DONOR)] : bais,
+                // In realign mode, prefer the current upstream alignment output over original BAM/CRAM input
+                params.realign_bam
+                    ? bams
+                    : (Utils.hasExistingInput(meta, Constants.INPUT.BAM_DNA_DONOR) ? [Utils.getInput(meta, Constants.INPUT.BAM_DNA_DONOR)] : bams),
+                params.realign_bam
+                    ? bais
+                    : (Utils.hasExistingInput(meta, Constants.INPUT.BAI_DNA_DONOR) ? [Utils.getInput(meta, Constants.INPUT.BAI_DNA_DONOR)] : bais),
             ]
         }
         .branch { meta, bams, bais ->

--- a/workflows/purity_estimate.nf
+++ b/workflows/purity_estimate.nf
@@ -42,7 +42,7 @@ workflow PURITY_ESTIMATE {
     purity_estimate_run_mode = Utils.getEnumFromString(params.purity_estimate_mode, Constants.RunMode)
 
     // Set up reference data, assign more human readable variables
-    prep_config = WorkflowMain.getPrepConfigFromSamplesheet(run_config)
+    prep_config = WorkflowMain.getPrepConfigFromSamplesheet(run_config, params)
     PREPARE_REFERENCE(
         prep_config,
         run_config,

--- a/workflows/targeted.nf
+++ b/workflows/targeted.nf
@@ -61,7 +61,7 @@ workflow TARGETED {
     ch_inputs = Channel.fromList(inputs)
 
     // Set up reference data, assign more human readable variables
-    prep_config = WorkflowMain.getPrepConfigFromSamplesheet(run_config)
+    prep_config = WorkflowMain.getPrepConfigFromSamplesheet(run_config, params)
     PREPARE_REFERENCE(
         prep_config,
         run_config,

--- a/workflows/wgts.nf
+++ b/workflows/wgts.nf
@@ -26,7 +26,9 @@ include { PEACH_CALLING         } from '../subworkflows/local/peach_calling'
 include { PREPARE_REFERENCE     } from '../subworkflows/local/prepare_reference'
 include { PURPLE_CALLING        } from '../subworkflows/local/purple_calling'
 include { READ_ALIGNMENT_DNA    } from '../subworkflows/local/read_alignment_dna'
+include { READ_ALIGNMENT_DNA_FROM_BAM } from '../subworkflows/local/read_alignment_dna_from_bam/main'
 include { READ_ALIGNMENT_RNA    } from '../subworkflows/local/read_alignment_rna'
+include { READ_ALIGNMENT_RNA_FROM_BAM } from '../subworkflows/local/read_alignment_rna_from_bam/main'
 include { REDUX_PROCESSING      } from '../subworkflows/local/redux_processing'
 include { SAGE_APPEND           } from '../subworkflows/local/sage_append'
 include { SAGE_CALLING          } from '../subworkflows/local/sage_calling'
@@ -88,6 +90,31 @@ workflow WGTS {
     ch_align_rna_tumor_out = Channel.empty()
     if (run_config.stages.alignment) {
 
+            if (params.realign_bam) {
+
+        READ_ALIGNMENT_DNA_FROM_BAM(
+            ch_inputs,
+            ref_data.genome_fasta,
+            ref_data.genome_bwamem2_index,
+        )
+
+        READ_ALIGNMENT_RNA_FROM_BAM(
+            ch_inputs,
+            ref_data.genome_star_index,
+        )
+
+        ch_versions = ch_versions.mix(
+            READ_ALIGNMENT_DNA_FROM_BAM.out.versions,
+            READ_ALIGNMENT_RNA_FROM_BAM.out.versions,
+        )
+
+        ch_align_dna_tumor_out  = ch_align_dna_tumor_out.mix(READ_ALIGNMENT_DNA_FROM_BAM.out.dna_tumor)
+        ch_align_dna_normal_out = ch_align_dna_normal_out.mix(READ_ALIGNMENT_DNA_FROM_BAM.out.dna_normal)
+        ch_align_dna_donor_out  = ch_align_dna_donor_out.mix(READ_ALIGNMENT_DNA_FROM_BAM.out.dna_donor)
+        ch_align_rna_tumor_out  = ch_align_rna_tumor_out.mix(READ_ALIGNMENT_RNA_FROM_BAM.out.rna_tumor)
+
+    } else {
+
         READ_ALIGNMENT_DNA(
             ch_inputs,
             ref_data.genome_fasta,
@@ -114,6 +141,7 @@ workflow WGTS {
         ch_align_dna_donor_out = ch_align_dna_donor_out.mix(READ_ALIGNMENT_DNA.out.dna_donor)
         ch_align_rna_tumor_out = ch_align_rna_tumor_out.mix(READ_ALIGNMENT_RNA.out.rna_tumor)
 
+    }
     } else {
 
         ch_align_dna_tumor_out = ch_inputs.map { meta -> [meta, [], []] }
@@ -122,6 +150,7 @@ workflow WGTS {
         ch_align_rna_tumor_out = ch_inputs.map { meta -> [meta, [], []] }
 
     }
+    
 
     //
     // SUBWORKFLOW: Run REDUX for DNA BAMs

--- a/workflows/wgts.nf
+++ b/workflows/wgts.nf
@@ -67,7 +67,7 @@ workflow WGTS {
     ch_inputs = Channel.fromList(inputs)
 
     // Set up reference data, assign more human readable variables
-    prep_config = WorkflowMain.getPrepConfigFromSamplesheet(run_config)
+    prep_config = WorkflowMain.getPrepConfigFromSamplesheet(run_config, params)
     PREPARE_REFERENCE(
         prep_config,
         run_config,


### PR DESCRIPTION
## PR checklist

This adds the workflow parameter `--realign_bam`, which enables the workflow to run from bams or cram input, but realign those bam/cram as if they were fastq. This is useful for bams/crams that do not meet the input requirements for Oncoanalyser (e.g. reads aligned to HLA alts, absence of the mate CIGAR tag). As much as possible, reads are streamed directly from the bams to reduce disk I/O and footprint.

This addresses #287 

I wasn't as sure about tests -- I have tested this extensively with local files. But I suspect it might be good to figure out a way of adapting the test suite to test this parameter?

- [ x ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ NA ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/oncoanalyser/tree/master/.github/CONTRIBUTING.md)
- [ NA ] If necessary, also make a PR on the nf-core/oncoanalyser _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ x ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ x ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ X ] Usage Documentation in `docs/usage.md` is updated.
- [ NA ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ NA ] `README.md` is updated (including new tool citations and authors/contributors).
