### PR TITLE
revert stub_run index check skip [skip ci]

### DIFF
--- a/lib/samplesheet/SampleSheet.groovy
+++ b/lib/samplesheet/SampleSheet.groovy
@@ -6,7 +6,7 @@ import util.Messages
 
 class SampleSheet {
 
-    public static List<Map> parse(String sample_sheet_path, PipelineMode pipeline_mode) {
+    public static List<Map> parse(String sample_sheet_path, PipelineMode pipeline_mode, boolean stub_run) {
 
         if (!sample_sheet_path) {
             throw new IllegalStateException("Missing required --input argument")
@@ -45,7 +45,7 @@ class SampleSheet {
                     def meta_sample = meta[sample_key]
 
                     // NOTE(LN): The order in which these methods are executed is important
-                    checkAndSetFileIndexes(meta_sample)
+                    checkAndSetFileIndexes(meta_sample, stub_run)
                     setCramPaths(meta_sample)
                     checkRawReadDataExists(meta_sample, group_id)
                     setReduxTsvDirIfUnset(meta_sample)
@@ -217,7 +217,7 @@ class SampleSheet {
 
     }
 
-    private static void checkAndSetFileIndexes(Map meta_sample) {
+    private static void checkAndSetFileIndexes(Map meta_sample, boolean stub_run) {
 
         // NOTE(LN): Cast keys to list to avoid ConcurrentModificationException
         meta_sample.keySet().toList().each { key ->
@@ -246,7 +246,7 @@ class SampleSheet {
             def file_path = meta_sample[key].toUriString()
             def index_path = nextflow.Nextflow.file("${file_path}.${index_extension}")
 
-            if (!index_path.exists()) {
+            if (!index_path.exists() && !stub_run) {
                 throw new IllegalStateException("Could not find index(${index_path}) for file(${file_path})")
             }
 

--- a/main.nf
+++ b/main.nf
@@ -81,7 +81,7 @@ workflow NFCORE_ONCOANALYSER {
         PREPARE_REFERENCE()
     } else {
 
-        def inputs = samplesheet.SampleSheet.parse(params.input, pipeline_mode)
+        def inputs = samplesheet.SampleSheet.parse(params.input, pipeline_mode, workflow.stubRun)
 
         def stages = pipeline.RunStage.getValidatedRunStages(
            params.processes_include,

--- a/modules/local/purple/main.nf
+++ b/modules/local/purple/main.nf
@@ -95,11 +95,15 @@ process PURPLE {
     touch purple/${meta.tumor_id}.purple.driver.catalog.germline.tsv
     touch purple/${meta.tumor_id}.purple.driver.catalog.somatic.tsv
     touch purple/${meta.tumor_id}.purple.germline.vcf.gz
+    touch purple/${meta.tumor_id}.purple.germline.vcf.gz.tbi
     touch purple/${meta.tumor_id}.purple.purity.tsv
     touch purple/${meta.tumor_id}.purple.qc
     touch purple/${meta.tumor_id}.purple.somatic.vcf.gz
+    touch purple/${meta.tumor_id}.purple.somatic.vcf.gz.tbi
     touch purple/${meta.tumor_id}.purple.sv.germline.vcf.gz
+    touch purple/${meta.tumor_id}.purple.sv.germline.vcf.gz.tbi
     touch purple/${meta.tumor_id}.purple.sv.vcf.gz
+    touch purple/${meta.tumor_id}.purple.sv.vcf.gz.tbi
 
     echo -e '${task.process}:\\n  stub: noversions\\n' > versions.yml
     """


### PR DESCRIPTION
To deal w/ failure of stub tests that appears to be due to [this](https://github.com/nf-core/oncoanalyser/commit/17f6b8865d9377c9e1cfa4d66e55ccb1ff967caf#diff-5fcde8c6ca1b97ba65f845b01fdd8339a1f6953efe9a492ffd03c6486ac64995L8-L45) commit which disabled the index validation skipped for the stub tests. 

I see 2 options to deal with the matter 1) add index entries in the stub test's samplesheet for clean validation (Luân's initial idea I assume?) or 2) revert to skipping the index validation for the stub tests. If 2 is favoured, code below. 

Additionally, the index files of the VCF generated by purple were not being created by the stubs (initial [issue](https://github.com/nf-core/oncoanalyser/issues/301) reported)

Fine w/ either option on my end! 

PS: skipped all ci testing due to nf-core template mismatch & other lingering snapshots differences, etc 