### PR TITLE
Revert use of faulty Apptainer setup action

### DIFF
--- a/.github/actions/nf-test/action.yml
+++ b/.github/actions/nf-test/action.yml
@@ -37,7 +37,7 @@ runs:
 
     - name: Setup apptainer
       if: contains(inputs.profile, 'singularity')
-      uses: eWaterCycle/setup-apptainer@4bb22c52d4f63406c49e94c804632975787312b3 # v2.0.0
+      uses: eWaterCycle/setup-apptainer@3f706d898c9db585b1d741b4692e66755f3a1b40 # v2
 
     - name: Set up Singularity
       if: contains(inputs.profile, 'singularity')


### PR DESCRIPTION
- nf-core template introduced a faulty action for apptainer setup
- this change reverts to a working action as suggested [here](https://nfcore.slack.com/archives/C04QR0T3G3H/p1784981383629609)